### PR TITLE
Add HCFS documentation

### DIFF
--- a/docs/hcfs/api/auth.md
+++ b/docs/hcfs/api/auth.md
@@ -1,0 +1,58 @@
+---
+id: auth
+title: Authentication
+sidebar_label: Authentication
+slug: /hcfs/api/auth
+---
+
+# Authentication
+
+Every authenticated HCFS endpoint requires a bearer token. The server resolves it to a Substrate SS58 address and enforces that the URL's `{ss58_address}` segment matches the resolved identity.
+
+## Header
+
+```
+Authorization: Bearer <token>
+```
+
+The token is whatever string the configured auth verifier accepts and maps to an SS58 address. The HCFS reference client sends the user's SS58 address itself as the token; a third-party client may send an opaque token issued by the auth service.
+
+## Identity binding
+
+Most endpoints embed the user's SS58 in the path:
+
+```
+GET  /get_state/{ss58_address}/{folder_hash}
+POST /register_relative_paths/{ss58_address}/{folder_hash}
+```
+
+The server rejects any request where the token's resolved SS58 does not match the path segment. This prevents one valid user from probing another user's namespace by guessing path parameters.
+
+## Billing bypass header
+
+Some deployments honour an additional header:
+
+```
+X-Billing-Bypass: <token>
+```
+
+When present and valid, the server skips billing checks for that request. Clients should only set this when their environment explicitly requires it.
+
+## Response behaviour
+
+| Status | Condition |
+|---|---|
+| 200-family | Token valid, identity matches path |
+| 401 `unauthorized` | Missing, malformed, or rejected token |
+| 403 `forbidden` | Token valid, but resolved SS58 does not match the URL's `{ss58_address}` segment |
+
+See [`errors.md`](./errors.md) for the full error envelope shape.
+
+## Unauthenticated endpoints
+
+| Path | Notes |
+|---|---|
+| `GET /health`, `/healthz`, `/readyz` | Liveness / readiness probes |
+| `GET /public/download/{hash}` | Retrieve a blob that a user has explicitly published by its content hash |
+
+All other endpoints require a bearer token.

--- a/docs/hcfs/api/browse.md
+++ b/docs/hcfs/api/browse.md
@@ -1,0 +1,127 @@
+---
+id: browse
+title: GET /browse/{ss58}/{folder_hash}
+sidebar_label: GET /browse
+slug: /hcfs/api/browse
+---
+
+# `GET /browse/{ss58}/{folder_hash}`
+
+Directory-scoped tree listing — returns immediate subfolders and the files at the given path, with pagination. Use this for a Finder / Explorer style UI where the user navigates one level at a time.
+
+For a flat listing of every file in a folder, use [`/get_state`](./get-state.md). For cross-folder search with filters, use [`/search_files`](./search-files.md).
+
+## Authentication
+
+`Authorization: Bearer <token>` matching `{ss58_address}`. See [`auth.md`](./auth.md).
+
+## Request
+
+### Method and path
+
+```
+GET /browse/{ss58_address}/{folder_hash}
+```
+
+### Path parameters
+
+| Name | Format | Notes |
+|---|---|---|
+| `ss58_address` | string | Owner's SS58 address |
+| `folder_hash` | 16-char hex | Folder label's hash |
+
+### Query parameters
+
+| Name | Type | Default | Notes |
+|---|---|---|---|
+| `path` | string | `""` (folder root) | Directory path relative to the folder root, POSIX-style (`Documents/2026`). Trailing slash optional. |
+| `offset` | `u32` | `0` | Starting index into the combined folders+files result set |
+| `limit` | `u32` | server default | Results per page |
+
+### Headers
+
+```
+Authorization: Bearer <token>
+```
+
+## Response — success (200)
+
+```json
+{
+  "Success": {
+    "ss58_address": "5Grw...",
+    "folder_hash":  "abc1234567890def",
+    "path":         "Documents/2026",
+    "folders": [
+      { "name": "taxes",  "file_count": 12, "total_bytes": 54321 },
+      { "name": "trips",  "file_count":  3, "total_bytes":  9876 }
+    ],
+    "files": [
+      {
+        "path_hash":    [ /* 32 bytes */ ],
+        "salted_hash":  [ /* 32 bytes */ ],
+        "size_bytes":   1048576,
+        "revision_seq": 1,
+        "revision_id":  [ /* 32 bytes */ ],
+        "encrypted_path": [ /* variable */ ],
+        "file_name":    "report.pdf",
+        "relative_path":"Documents/2026/report.pdf",
+        "arion_hash":   "Qm...",
+        "chunk_hashes": null,
+        "created_at":   1713139200,
+        "updated_at":   1713139200
+      }
+    ],
+    "total_count": 8,
+    "has_more":    false,
+    "offset":      0,
+    "limit":       25
+  }
+}
+```
+
+### Sort order
+
+1. Folders first, alphabetical, case-insensitive.
+2. Files second, alphabetical case-insensitive by `file_name`, tiebreak by `path_hash`.
+
+### Subfolder aggregates
+
+`file_count` and `total_bytes` on each `BrowseFolderEntry` are **recursive** — they count every descendant of the subfolder, not just direct children. This matches Finder / Explorer UX where clicking a folder shows the full size summary regardless of nesting.
+
+### File shape
+
+Identical to the `RemoteFileEntry` returned by [`/get_state`](./get-state.md#remotefileentry-fields).
+
+### Pagination
+
+`total_count = folders.len() + count(files at this exact path)`. `has_more` is `true` iff `offset + (folders + files in this page) < total_count`.
+
+## Response — errors
+
+Shared envelope shape in [`errors.md`](./errors.md).
+
+| Status | `error` code | Cause |
+|---|---|---|
+| `400` | `invalid_user_id` / validator errors from `path` | Malformed SS58, or `path` contains `..`, backslashes, etc. |
+| `401` | `unauthorized` | Missing / bad bearer token |
+| `403` | `forbidden` | Token resolves to a different SS58 than the path |
+| `500` | `database_error` | Transient — retry with backoff |
+
+## Example
+
+```bash
+# Browse the folder root
+curl -H "Authorization: Bearer $SS58" \
+     "$SERVER/browse/$SS58/$FOLDER_HASH"
+
+# Browse a subdirectory
+curl -H "Authorization: Bearer $SS58" \
+     "$SERVER/browse/$SS58/$FOLDER_HASH?path=Documents/2026&limit=100"
+```
+
+## Notes
+
+- **Files without a `relative_path` are hidden from browse.** Legacy rows (uploaded before relative-path support) will not appear here until the client backfills them via [`/register_relative_paths`](./register-relative-paths.md). They still appear in `/get_state` and in sync.
+- Empty directories return a 200 with empty `folders` and `files` arrays — not a 404.
+- The endpoint pages the combined folders+files stream, not folders and files separately. If you need to page them independently, consider using `/search_files` with explicit filters.

--- a/docs/hcfs/api/delete.md
+++ b/docs/hcfs/api/delete.md
@@ -1,0 +1,79 @@
+---
+id: delete
+title: DELETE /delete/{ss58}/{folder_hash}/{file_id}
+sidebar_label: DELETE /delete
+slug: /hcfs/api/delete
+---
+
+# `DELETE /delete/{ss58}/{folder_hash}/{file_id}`
+
+Remove one file from a folder: drops the `file_records` row, decrements the user's storage summary, and deletes the ciphertext blob from storage.
+
+## Authentication
+
+`Authorization: Bearer <token>`. The token's resolved SS58 must match the `{ss58_address}` path segment. See [`auth.md`](./auth.md).
+
+## Request
+
+### Method and path
+
+```
+DELETE /delete/{ss58_address}/{folder_hash}/{file_id}
+```
+
+### Path parameters
+
+| Name | Format | Notes |
+|---|---|---|
+| `ss58_address` | string | Owner's SS58 address |
+| `folder_hash` | 16-char hex | Folder label's hash |
+| `file_id` | 64-char hex | `path_hash` of the file |
+
+### Headers
+
+```
+Authorization: Bearer <token>
+```
+
+### Body
+
+None.
+
+## Response — success (200)
+
+```json
+{
+  "Success": {
+    "status":       "deleted",
+    "file_id":      "<64-char hex>",
+    "ss58_address": "5Grw...",
+    "folder_hash":  "abc1234567890def"
+  }
+}
+```
+
+## Response — errors
+
+Shared envelope shape in [`errors.md`](./errors.md).
+
+| Status | `error` code | Cause |
+|---|---|---|
+| `400` | `invalid_file_id` | `file_id` is not valid 64-char hex |
+| `401` | `unauthorized` | Missing / bad bearer token |
+| `403` | `forbidden` | Token resolves to a different SS58 than the path |
+| `404` | `not_found` | No file at this `(ss58_address, folder_hash, path_hash)` |
+| `500` | `database_error` | Transient — retry with backoff |
+
+## Example
+
+```bash
+curl -X DELETE \
+     -H "Authorization: Bearer $SS58" \
+     "$SERVER/delete/$SS58/$FOLDER_HASH/$FILE_ID"
+```
+
+## Notes
+
+- Deletion is immediate. There is no undo endpoint.
+- To remove every file in a folder in one call, use [`/unregister_folder`](./folders.md#delete-unregister_folder) instead.
+- Concurrent deletes of the same file are idempotent: the first caller gets `200 Success`, subsequent callers get `404 not_found`.

--- a/docs/hcfs/api/download.md
+++ b/docs/hcfs/api/download.md
@@ -1,0 +1,101 @@
+---
+id: download
+title: GET /download/{ss58}/{folder_hash}/{file_id}
+sidebar_label: GET /download
+slug: /hcfs/api/download
+---
+
+# `GET /download/{ss58}/{folder_hash}/{file_id}`
+
+Stream the stored ciphertext for one file, along with the metadata needed to drive a progress bar and to maintain the three-tree sync state.
+
+## Authentication
+
+`Authorization: Bearer <token>`. The token's resolved SS58 must match the `{ss58_address}` path segment. See [`auth.md`](./auth.md).
+
+## Request
+
+### Method and path
+
+```
+GET /download/{ss58_address}/{folder_hash}/{file_id}
+```
+
+### Path parameters
+
+| Name | Format | Notes |
+|---|---|---|
+| `ss58_address` | string | Owner's SS58 address |
+| `folder_hash` | 16-char hex | First 16 chars of `SHA-256(folder_label)` |
+| `file_id` | 64-char hex | Hex encoding of `path_hash` (BLAKE3 of the relative path) |
+
+### Headers
+
+```
+Authorization: Bearer <token>
+Range:         bytes=<start>-<end>     # optional, for partial content
+```
+
+### Query parameters
+
+None.
+
+## Response — success
+
+### Status
+
+| Status | When |
+|---|---|
+| `200 OK` | Full blob returned |
+| `206 Partial Content` | `Range:` header was honored |
+
+### Response headers
+
+| Header | Meaning |
+|---|---|
+| `Content-Length` | **Ciphertext** bytes. Drives HTTP progress. May be omitted when the storage layer cannot report a length — clients must handle chunked transfer. |
+| `X-Size-Bytes` | **Plaintext** bytes. Display this in the UI. |
+| `X-Revision-Id` | 64-char hex — the file's current revision |
+| `X-Revision-Seq` | u64 — monotonic revision sequence |
+| `X-File-Id` | Echo of the URL's `{file_id}` |
+| `X-Ss58-Address` | Echo of the URL's `{ss58_address}` |
+| `X-Folder-Hash` | Echo of the URL's `{folder_hash}` |
+| `Accept-Ranges` | `bytes` — partial-content is supported |
+| `Content-Range` | Set on `206 Partial Content` responses |
+
+### Body
+
+Raw ciphertext bytes in the HCFS chunked wire format. See [`upload.md`](./upload.md#ciphertext-wire-format) for the framing layout and the per-chunk nonce derivation.
+
+## Response — errors
+
+Shared envelope shape in [`errors.md`](./errors.md).
+
+| Status | `error` code | Cause |
+|---|---|---|
+| `400` | `invalid_file_id` | `file_id` is not valid 64-char hex |
+| `401` | `unauthorized` | Missing / bad bearer token |
+| `403` | `forbidden` | Token resolves to a different SS58 than the path |
+| `404` | `not_found` | No file at this `(ss58_address, folder_hash, path_hash)` |
+| `500` | `storage_inconsistency` | Metadata row exists but the ciphertext blob is missing — retry with backoff; re-surface to logs if persistent |
+
+## Example
+
+```bash
+curl -H "Authorization: Bearer $SS58" \
+     -o "file.enc" \
+     -D "headers.txt" \
+     "$SERVER/download/$SS58/$FOLDER_HASH/$FILE_ID"
+
+# Range request (resumable download)
+curl -H "Authorization: Bearer $SS58" \
+     -H "Range: bytes=1048576-" \
+     -o "file.enc.part2" \
+     "$SERVER/download/$SS58/$FOLDER_HASH/$FILE_ID"
+```
+
+## Notes
+
+- To decrypt the returned bytes, you need the per-file `encryption_key` derived from the same mnemonic that was used to sign the upload.
+- `Content-Length` and `X-Size-Bytes` differ because encryption adds framing overhead (24-byte base nonce + 4-byte count + 20 bytes per chunk). Use `X-Size-Bytes` for any user-facing file-size UI, and `Content-Length` only for HTTP transfer progress.
+- The `file_id` is stable across revisions — only the content, `revision_id`, and `revision_seq` change.

--- a/docs/hcfs/api/errors.md
+++ b/docs/hcfs/api/errors.md
@@ -1,0 +1,82 @@
+---
+id: errors
+title: Errors and Response Envelope
+sidebar_label: Errors
+slug: /hcfs/api/errors
+---
+
+# Errors and Response Envelope
+
+Every HCFS JSON response is wrapped in a `NetworkResponse<T>` envelope with exactly three variants: `Success`, `Conflict`, and `Error`. The variant name is the outer JSON key.
+
+## Envelope
+
+### Success
+
+```json
+{ "Success": { /* endpoint-specific payload, see individual endpoint pages */ } }
+```
+
+### Error
+
+```json
+{
+  "Error": {
+    "error":   "<machine-readable code>",
+    "message": "<human-readable explanation>"
+  }
+}
+```
+
+The `error` field is a stable string the client can switch on. `message` is intended for logs and UI; wording is not part of the API contract and may change.
+
+### Conflict
+
+Only returned by write endpoints when an optimistic-concurrency check fails. Carries the current server state so the client can re-reconcile without re-fetching:
+
+```json
+{
+  "Conflict": {
+    "error":                "conflict",
+    "message":              "...",
+    "current_revision_id":  [/* 32 bytes */],
+    "current_revision_seq": 42
+  }
+}
+```
+
+## Status code catalog
+
+| Status | Codes | Meaning |
+|---|---|---|
+| `400` | `invalid_manifest`, `stale_sequence`, `invalid_file_id`, `invalid_user_id`, `batch_too_large`, `q_too_long`, `invalid_file_type` | Malformed request, payload fails validation, revision_seq ≤ current, or a batch exceeded its entry / body cap |
+| `401` | `unauthorized` | Missing, malformed, or rejected bearer token |
+| `403` | `forbidden` | Token valid but resolved SS58 does not match the URL path segment |
+| `404` | `not_found` | No such file, folder, or session for this user |
+| `409` | `conflict`, `upload_conflict` | `base_revision_id` in the request does not match the current server revision — re-fetch state and retry |
+| `500` | `database_error`, `storage_inconsistency` | Server-side failure; safe to retry with backoff |
+
+Endpoint pages list any additional codes specific to their handler.
+
+## Optimistic concurrency (409 / `Conflict`)
+
+HCFS uses optimistic concurrency on every write that modifies a file: the client sends the `base_revision_id` it believed was current. The server compares it to the row's current revision and rejects mismatches with `409 Conflict`, returning the authoritative state in the envelope.
+
+On `Conflict`:
+
+1. Update the local representation with `current_revision_id` / `current_revision_seq`.
+2. Re-run the sync classification to decide whether the local change and remote change can be merged, or whether the user must pick a winner.
+3. Retry the write with the new `base_revision_id`.
+
+New files send `base_revision_id = null`. If a file already exists at that `path_hash`, the server returns `409 conflict` — treat it as an unexpected-existing-file case and sync before retrying.
+
+## Per-entry partial success
+
+A few endpoints (e.g. [`/register_relative_paths`](./register-relative-paths.md), [`/rename_files`](./rename-files.md)) always return `200 Success` even when individual entries fail. Those endpoints include per-entry `errors` / `failures` arrays inside their success payload. Clients **must** inspect those arrays — HTTP status alone does not convey per-entry outcomes.
+
+## Client policy recommendations
+
+- Treat `401` / `403` / `404` as terminal; fix the request.
+- Treat `409` as an expected sync event, not an error. Handle as above.
+- Treat `500` as transient; back off and retry up to a small, bounded number of times.
+- Treat unknown `error` codes as terminal and surface to logs — they indicate a server upgrade the client hasn't been updated for.

--- a/docs/hcfs/api/folders.md
+++ b/docs/hcfs/api/folders.md
@@ -1,0 +1,195 @@
+---
+id: folders
+title: Folder lifecycle
+sidebar_label: Folders
+slug: /hcfs/api/folders
+---
+
+# Folder lifecycle
+
+Three endpoints for the folder registry: register a new folder, list a user's folders, unregister (and delete) a folder. Folder registration is what makes `folder_label` show up in [`/list_folders`](./folders.md#get-list_foldersbase_address) and [`/search_files`](./search-files.md); files can still be uploaded to an unregistered `folder_hash`, they just surface with `folder_label = ""`.
+
+---
+
+## `POST /register_folder` {#post-register_folder}
+
+Declare a new sync folder under an SS58 address.
+
+### Authentication
+
+`Authorization: Bearer <token>` matching `ss58_address` in the request body. See [`auth.md`](./auth.md).
+
+### Request
+
+```
+POST /register_folder
+Content-Type:  application/json
+Authorization: Bearer <token>
+```
+
+```json
+{
+  "ss58_address": "5Grw...",
+  "folder_hash":  "abc1234567890def",
+  "label":        "My Documents",
+  "device_name":  "laptop-home"
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `ss58_address` | string | Owner's SS58 (accepts alias `user_id`) |
+| `folder_hash` | 16-char hex | First 16 chars of `SHA-256(label)` — the client computes this |
+| `label` | string | Human-readable folder name |
+| `device_name` | `string \| null` | Optional — records which device first registered this folder |
+
+### Response — success (200)
+
+```json
+{ "Success": { "status": "registered" } }
+```
+
+### Response — errors
+
+| Status | `error` code | Cause |
+|---|---|---|
+| `400` | `invalid_manifest` | Body malformed or required field missing |
+| `401` | `unauthorized` | Missing / bad bearer token |
+| `403` | `forbidden` | Token resolves to a different SS58 than `ss58_address` |
+| `409` | `conflict` | A folder with this `folder_hash` is already registered for this user |
+| `500` | `database_error` | Transient |
+
+### Example
+
+```bash
+curl -X POST "$SERVER/register_folder" \
+  -H "Authorization: Bearer $SS58" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "ss58_address": "'"$SS58"'",
+    "folder_hash":  "abc1234567890def",
+    "label":        "My Documents",
+    "device_name":  "laptop-home"
+  }'
+```
+
+---
+
+## `GET /list_folders/{base_address}` {#get-list_foldersbase_address}
+
+Enumerate every folder a user has registered, with per-folder file count and total size.
+
+### Authentication
+
+`Authorization: Bearer <token>` matching `{base_address}`.
+
+### Request
+
+```
+GET /list_folders/{base_address}
+Authorization: Bearer <token>
+```
+
+### Response — success (200)
+
+```json
+{
+  "Success": {
+    "base_address": "5Grw...",
+    "folders": [
+      {
+        "label":       "My Documents",
+        "folder_hash": "abc1234567890def",
+        "file_count":  142,
+        "total_bytes": 943718400,
+        "created_at":  1713139200,
+        "updated_at":  1713225600,
+        "device_name": "laptop-home"
+      }
+    ]
+  }
+}
+```
+
+| `RemoteFolderInfo` field | Type | Notes |
+|---|---|---|
+| `label` | string | Human-readable folder name from registration |
+| `folder_hash` | 16-char hex | Use this in path parameters of other endpoints |
+| `file_count` | `u64` | Files currently in the folder |
+| `total_bytes` | `u64` | Sum of plaintext sizes |
+| `created_at` | `i64` | Unix seconds when the folder was registered |
+| `updated_at` | `i64` | Unix seconds when a file in the folder last changed |
+| `device_name` | string | `""` when the folder was registered without one |
+
+### Response — errors
+
+| Status | `error` code | Cause |
+|---|---|---|
+| `400` | `invalid_user_id` | `base_address` malformed |
+| `401` | `unauthorized` | Missing / bad bearer token |
+| `403` | `forbidden` | Token resolves to a different SS58 than `{base_address}` |
+
+### Example
+
+```bash
+curl -H "Authorization: Bearer $SS58" \
+     "$SERVER/list_folders/$SS58"
+```
+
+---
+
+## `DELETE /unregister_folder` {#delete-unregister_folder}
+
+Remove a folder and **every file it owns**. Storage blobs for every file in the folder are scheduled for deletion.
+
+### Authentication
+
+`Authorization: Bearer <token>` matching `ss58_address` in the request body.
+
+### Request
+
+```
+DELETE /unregister_folder
+Content-Type:  application/json
+Authorization: Bearer <token>
+```
+
+```json
+{ "ss58_address": "5Grw...", "folder_hash": "abc1234567890def" }
+```
+
+### Response — success (200)
+
+```json
+{
+  "Success": {
+    "status":        "unregistered",
+    "files_deleted": 142
+  }
+}
+```
+
+### Response — errors
+
+| Status | `error` code | Cause |
+|---|---|---|
+| `400` | `invalid_manifest` | Body malformed |
+| `401` | `unauthorized` | Missing / bad bearer token |
+| `403` | `forbidden` | SS58 mismatch |
+| `404` | `not_found` | No folder registered at this `folder_hash` for this user |
+| `500` | `database_error` | Transient |
+
+### Example
+
+```bash
+curl -X DELETE "$SERVER/unregister_folder" \
+  -H "Authorization: Bearer $SS58" \
+  -H "Content-Type: application/json" \
+  -d '{ "ss58_address": "'"$SS58"'", "folder_hash": "abc1234567890def" }'
+```
+
+## Notes
+
+- `folder_hash` is deterministic: same `label` always produces the same hash. This lets multiple devices register the same folder without coordination — the second caller gets `409 conflict` and can proceed assuming the folder exists.
+- Unregistering is destructive and irreversible. To delete a single file instead, use [`/delete`](./delete.md).
+- You can upload files to a `folder_hash` that was never registered — they will show up in `/get_state` but with `folder_label = ""` in `/search_files` results. Registering after-the-fact adds the label.

--- a/docs/hcfs/api/get-state.md
+++ b/docs/hcfs/api/get-state.md
@@ -1,0 +1,131 @@
+---
+id: get-state
+title: GET /get_state/{ss58}/{folder_hash}
+sidebar_label: GET /get_state
+slug: /hcfs/api/get-state
+---
+
+# `GET /get_state/{ss58}/{folder_hash}`
+
+Paginated listing of every file the user has in a folder. This is the primary input to a client's remote-tree reconstruction: walk it in order, page by page, and build a `path_hash → RemoteFileEntry` map.
+
+For a directory-scoped tree view, see [`/browse`](./browse.md). For cross-folder filename/size/date search, see [`/search_files`](./search-files.md).
+
+## Authentication
+
+`Authorization: Bearer <token>` matching `{ss58_address}`. See [`auth.md`](./auth.md).
+
+## Request
+
+### Method and path
+
+```
+GET /get_state/{ss58_address}/{folder_hash}
+```
+
+### Path parameters
+
+| Name | Format | Notes |
+|---|---|---|
+| `ss58_address` | string | Owner's SS58 address |
+| `folder_hash` | 16-char hex | Folder label's hash |
+
+### Query parameters
+
+| Name | Type | Default | Notes |
+|---|---|---|---|
+| `offset` | `u32` | `0` | Starting index into the full ordered result set |
+| `limit` | `u32` | server default | Results per page (capped server-side; consult server-config for exact max) |
+
+### Headers
+
+```
+Authorization: Bearer <token>
+```
+
+### Body
+
+None.
+
+## Response — success (200)
+
+```json
+{
+  "Success": {
+    "ss58_address": "5Grw...",
+    "folder_hash":  "abc1234567890def",
+    "files": [
+      {
+        "path_hash":    [ /* 32 bytes */ ],
+        "salted_hash":  [ /* 32 bytes */ ],
+        "size_bytes":   1048576,
+        "revision_seq": 1,
+        "revision_id":  [ /* 32 bytes */ ],
+        "encrypted_path": [ /* variable length ciphertext */ ],
+        "file_name":    "report.pdf",
+        "relative_path":"Work/report.pdf",
+        "arion_hash":   "Qm...",
+        "chunk_hashes": ["Qm...", "Qm..."],
+        "created_at":   1713139200,
+        "updated_at":   1713139200
+      }
+    ],
+    "total_count": 142,
+    "has_more":    true,
+    "offset":      0,
+    "limit":       25
+  }
+}
+```
+
+### `RemoteFileEntry` fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `path_hash` | `[u8; 32]` | Stable file identifier (`BLAKE3(relative_path)`) |
+| `salted_hash` | `[u8; 32]` | `BLAKE3(ss58 ‖ plaintext)` — content-equality check that doesn't depend on the nonce |
+| `size_bytes` | `u64` | Plaintext size |
+| `revision_seq` | `u64` | Monotonic revision counter |
+| `revision_id` | `[u8; 32]` | Opaque version identifier |
+| `encrypted_path` | `Vec<u8>` | Chunked-encrypted relative path; may be empty |
+| `file_name` | `string \| null` | Plaintext filename. `null` for legacy rows |
+| `relative_path` | `string \| null` | Plaintext relative path. `null` for legacy rows; backfill via [`/register_relative_paths`](./register-relative-paths.md) |
+| `arion_hash` | `string \| null` | Content hash from the storage backend. `null` when metadata is unavailable |
+| `chunk_hashes` | `string[] \| null` | Per-chunk content hashes for chunk-native files. `null` / empty for single-blob files |
+| `created_at` | `i64` | Unix seconds |
+| `updated_at` | `i64` | Unix seconds |
+
+## Response — errors
+
+Shared envelope shape in [`errors.md`](./errors.md).
+
+| Status | `error` code | Cause |
+|---|---|---|
+| `400` | `invalid_user_id` | `ss58_address` empty, > 256 bytes, or contains illegal characters |
+| `401` | `unauthorized` | Missing / bad bearer token |
+| `403` | `forbidden` | Token resolves to a different SS58 than `{ss58_address}` |
+| `500` | `database_error` | Transient — retry with backoff |
+
+## Pagination
+
+- `total_count` is the number of files across the whole folder, not just the current page.
+- `has_more` is `true` iff `offset + returned_count < total_count`.
+- Stable ordering: results are sorted by an internal primary key that does not change between pages, so paging through a dataset does not drop or repeat entries.
+
+## Example
+
+```bash
+# First page
+curl -H "Authorization: Bearer $SS58" \
+     "$SERVER/get_state/$SS58/$FOLDER_HASH?offset=0&limit=100"
+
+# Subsequent pages — loop until has_more is false
+curl -H "Authorization: Bearer $SS58" \
+     "$SERVER/get_state/$SS58/$FOLDER_HASH?offset=100&limit=100"
+```
+
+## Notes
+
+- This endpoint is the canonical source for the remote `FileTree` consumed by the three-tree sync engine.
+- Files without a `relative_path` are still returned — they are visible in sync but hidden from [`/browse`](./browse.md) and [`/search_files`](./search-files.md) until the client backfills via [`/register_relative_paths`](./register-relative-paths.md).
+- Clients should cache `revision_id` from the most recent `get_state` response and pass it as `base_revision_id` on subsequent writes to that file.

--- a/docs/hcfs/api/overview.md
+++ b/docs/hcfs/api/overview.md
@@ -1,0 +1,98 @@
+---
+id: overview
+title: HCFS REST API Reference
+sidebar_label: Overview
+slug: /hcfs/api/overview
+---
+
+# HCFS REST API Reference
+
+The authoritative description of every HCFS HTTP endpoint. Each endpoint has its own page with request shape, response shape, status codes, and a working `curl` example.
+
+Before reading an endpoint page, skim [`auth.md`](./auth.md) and [`errors.md`](./errors.md) — every endpoint assumes that model.
+
+- **Base URL:** `https://<server>/`
+- **Transport:** HTTPS (TLS terminated upstream)
+- **Content types:** `application/json` for request/response bodies, `multipart/form-data` for uploads, `application/octet-stream` for ciphertext downloads
+
+---
+
+## Prerequisites
+
+| Page | What it covers |
+|---|---|
+| [`auth.md`](./auth.md) | Bearer-token model, identity resolution, 401 / 403 behaviour |
+| [`errors.md`](./errors.md) | `NetworkResponse<T>` envelope, error-code catalog, optimistic concurrency |
+
+---
+
+## Endpoint index
+
+### File lifecycle — HCFS native (end-to-end encrypted)
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| [`/upload`](./upload.md) | POST | Upload a signed manifest + ciphertext for one file |
+| [`/download/{ss58}/{folder_hash}/{file_id}`](./download.md) | GET | Stream the ciphertext back, with metadata headers |
+| [`/delete/{ss58}/{folder_hash}/{file_id}`](./delete.md) | DELETE | Remove ciphertext + metadata for one file |
+
+### File lifecycle — S3-compatible gateway (server-side only)
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| [`/upload`](./s3-gateway.md#post-upload) | POST | Upload a plain file with `account_ss58` + `file` fields (no manifest, no client-side encryption) |
+| [`/download/{ss58}/{file_id}`](./s3-gateway.md#get-downloadss58file_id) | GET | Stream file by ID without folder scope |
+| [`/delete/{ss58}/{file_id}`](./s3-gateway.md#delete-deletess58file_id) | DELETE | Remove file by ID without folder scope |
+
+### State and discovery
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| [`/get_state/{ss58}/{folder_hash}`](./get-state.md) | GET | Paginated listing of every file in a folder |
+| [`/browse/{ss58}/{folder_hash}`](./browse.md) | GET | Directory-scoped tree listing with subfolder aggregates |
+| [`/search_files/{ss58}`](./search-files.md) | GET | Cross-folder file search with filters, sort, pagination |
+| [`/register_relative_paths/{ss58}/{folder_hash}`](./register-relative-paths.md) | POST | Backfill plaintext relative paths for legacy rows |
+
+### Folder lifecycle
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| [`/register_folder`](./folders.md#post-register_folder) | POST | Declare a new sync folder under an SS58 address |
+| [`/list_folders/{base_address}`](./folders.md#get-list_foldersbase_address) | GET | Enumerate every folder a user has registered |
+| [`/unregister_folder`](./folders.md#delete-unregister_folder) | DELETE | Remove a folder and every file record it owns |
+
+### Rename
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| [`/rename_files`](./rename-files.md) | POST | Atomic batch rename — re-keys file records without touching storage |
+
+### Resumable / chunked upload
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| [`/upload/session`](./upload-session.md#post-uploadsession) | POST | Open a chunked upload session |
+| [`/upload/session/{id}/chunk/{index}`](./upload-session.md#put-uploadsessionidchunkindex) | PUT | Upload one chunk (≤ 16 MiB) |
+| [`/upload/session/{id}/status`](./upload-session.md#get-uploadsessionidstatus) | GET | Inspect session progress and resume point |
+| [`/upload/session/{id}/finalize`](./upload-session.md#post-uploadsessionidfinalize) | POST | Assemble chunks and commit the file |
+| [`/upload/session/{id}`](./upload-session.md#delete-uploadsessionid) | DELETE | Abort and clean up a session |
+
+---
+
+## Response envelope
+
+Every endpoint's JSON body is shaped as one of:
+
+```json
+{ "Success": { ... endpoint-specific payload ... } }
+{ "Conflict": { "error": "...", "message": "...", "current_revision_id": [...], "current_revision_seq": 0 } }
+{ "Error":    { "error": "<code>", "message": "<human-readable>" } }
+```
+
+See [`errors.md`](./errors.md) for the code catalog and the optimistic-concurrency rules that produce `Conflict`.
+
+---
+
+## Authentication in one line
+
+Send `Authorization: Bearer <token>`. The server resolves the token to an SS58 address and refuses requests whose URL `{ss58_address}` segment does not match. See [`auth.md`](./auth.md).

--- a/docs/hcfs/api/register-relative-paths.md
+++ b/docs/hcfs/api/register-relative-paths.md
@@ -1,0 +1,112 @@
+---
+id: register-relative-paths
+title: POST /register_relative_paths/{ss58}/{folder_hash}
+sidebar_label: POST /register_relative_paths
+slug: /hcfs/api/register-relative-paths
+---
+
+# `POST /register_relative_paths/{ss58}/{folder_hash}`
+
+Backfill plaintext `relative_path` values for file rows that were uploaded before the field existed. After a successful call, those rows become visible in [`/browse`](./browse.md) and [`/search_files`](./search-files.md) results.
+
+The server never overwrites an existing non-null `relative_path` with a different value — calls against already-populated rows land in `skipped`, not `updated`.
+
+## Authentication
+
+`Authorization: Bearer <token>` matching `{ss58_address}`. See [`auth.md`](./auth.md).
+
+## Request
+
+### Method and path
+
+```
+POST /register_relative_paths/{ss58_address}/{folder_hash}
+```
+
+### Headers
+
+```
+Authorization: Bearer <token>
+Content-Type:  application/json
+```
+
+### Body
+
+```json
+{
+  "entries": [
+    { "path_hash": "<64-char hex>", "relative_path": "Documents/report.pdf" },
+    { "path_hash": "<64-char hex>", "relative_path": "photos/trip/IMG_0001.jpg" }
+  ]
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `entries` | array | ≤ 500 entries per call (server rejects with `batch_too_large` above). Total request body ≤ 4 MiB. |
+| `entries[].path_hash` | 64-char hex | Hex encoding of the row's `path_hash` (`BLAKE3(relative_path)`) |
+| `entries[].relative_path` | string | Plaintext relative path — validated server-side against a path whitelist |
+
+## Response — success (200, partial-success)
+
+The endpoint **always** returns `200 Success` even when every entry fails. Inspect the `errors` array to detect failures.
+
+```json
+{
+  "Success": {
+    "updated": 47,
+    "skipped": 3,
+    "errors": [
+      {
+        "path_hash": "<64-char hex of failing entry>",
+        "reason":    "invalid_path"
+      }
+    ]
+  }
+}
+```
+
+| Field | Meaning |
+|---|---|
+| `updated` | Count of rows that transitioned from NULL to a valid `relative_path` |
+| `skipped` | Count of entries where the row already had a matching `relative_path` (idempotent no-op) or did not exist |
+| `errors` | Per-entry failures. Each carries the hex `path_hash` of the failing entry and a `reason` code. |
+
+### Known `reason` codes
+
+| `reason` | Meaning |
+|---|---|
+| `invalid_path` | Failed `path_validator` (contains `..`, backslashes, null bytes, etc.) |
+| `not_found` | No `file_records` row at this `path_hash` for this `(ss58, folder)` |
+| `path_mismatch` | Row already has a different non-null `relative_path` — the server refuses to overwrite |
+| `database_error` | Transient per-entry DB failure; safe to retry this entry |
+
+## Response — errors (non-200)
+
+Only request-level failures produce an `Error` envelope:
+
+| Status | `error` code | Cause |
+|---|---|---|
+| `400` | `invalid_manifest` / `batch_too_large` | Body JSON malformed, or `entries.len() > 500`, or body > 4 MiB |
+| `401` | `unauthorized` | Missing / bad bearer token |
+| `403` | `forbidden` | Token resolves to a different SS58 than the path |
+
+## Example
+
+```bash
+curl -X POST "$SERVER/register_relative_paths/$SS58/$FOLDER_HASH" \
+  -H "Authorization: Bearer $SS58" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "entries": [
+      { "path_hash": "abcd...", "relative_path": "Documents/report.pdf" },
+      { "path_hash": "ef01...", "relative_path": "photos/IMG_0001.jpg" }
+    ]
+  }'
+```
+
+## Notes
+
+- Idempotent: calling with an entry that already matches the stored `relative_path` lands in `skipped`, not as an error.
+- Typical use: after a desktop client upgrades to a version that sends `relative_path` on new uploads, it walks `/get_state`, identifies rows with `relative_path = null`, and calls this endpoint in batches of 500 with the local plaintext paths.
+- Plaintext relative paths leave the client for the first time when you call this endpoint. If path privacy matters in your deployment, decide whether to opt in.

--- a/docs/hcfs/api/rename-files.md
+++ b/docs/hcfs/api/rename-files.md
@@ -1,0 +1,154 @@
+---
+id: rename-files
+title: POST /rename_files
+sidebar_label: POST /rename_files
+slug: /hcfs/api/rename-files
+---
+
+# POST /rename_files
+
+Atomic batch rename. Re-keys file records in the database — changes the `path_hash` (and optionally the encrypted / plaintext path metadata) without re-uploading the ciphertext. Every rename in the batch is signed together with one Ed25519 signature.
+
+Use this instead of "upload at new path + delete at old path" whenever the file content hasn't changed — it's atomic, cheaper, and preserves revision history.
+
+## Authentication
+
+`Authorization: Bearer <token>` matching `ss58_address` in the request body. See [`auth.md`](./auth.md). In addition, the server verifies an Ed25519 signature over a deterministic serialization of the renames — see *Signature scheme* below.
+
+## Request
+
+### Method and path
+
+```
+POST /rename_files
+```
+
+### Headers
+
+```
+Authorization: Bearer <token>
+Content-Type:  application/json
+```
+
+### Body
+
+```json
+{
+  "ss58_address": "5Grw...",
+  "folder_hash":  "abc1234567890def",
+  "renames": [
+    {
+      "old_path_hash":      [ /* 32 bytes */ ],
+      "new_path_hash":      [ /* 32 bytes */ ],
+      "new_encrypted_path": [ /* variable-length ciphertext */ ],
+      "new_file_name":      "renamed.pdf",
+      "new_relative_path":  "Documents/2026/renamed.pdf",
+      "base_revision_id":   [ /* 32 bytes */ ]
+    }
+  ],
+  "signature":   [ /* 64 bytes */ ],
+  "signing_key": [ /* 32 bytes */ ]
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `ss58_address` | string | Owner's SS58 (accepts alias `user_id`) |
+| `folder_hash` | 16-char hex | Folder whose files are being renamed |
+| `renames[]` | array | One `SingleRename` per file to rename |
+| `signature` | `[u8; 64]` | Ed25519 signature over the canonical text — see below |
+| `signing_key` | `[u8; 32]` | Ed25519 public verifying key |
+
+### `SingleRename` fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `old_path_hash` | `[u8; 32]` | Current `path_hash` of the file — must exist for this `(ss58, folder)` |
+| `new_path_hash` | `[u8; 32]` | Target `path_hash` — must not already exist at this `(ss58, folder)` |
+| `new_encrypted_path` | `Vec<u8>` | New ciphertext for the encrypted path. Empty is allowed. |
+| `new_file_name` | `string \| null` | Plaintext filename for UI / progress |
+| `new_relative_path` | `string \| null` | Plaintext relative path. Optional. |
+| `base_revision_id` | `[u8; 32]` | Client's view of the file's current revision — used for optimistic concurrency per-rename |
+
+### Signature scheme
+
+The signature covers a deterministic text built from the sorted list of `(old → new)` hex hash pairs:
+
+```
+sorted_renames = renames.sort_by(r => r.old_path_hash)
+pairs          = sorted_renames.map(r => "hex(old_path_hash):hex(new_path_hash)")
+text           = "I hereby declare that I am renaming the following files on HCFS with the understanding that I have read and agree to the Terms of Service: " + pairs.join(",")
+signature      = Ed25519::sign(signing_key, text.as_bytes())
+```
+
+The server computes the same text from the received `renames` array and rejects mismatches. Sorting is performed server-side by `old_path_hash` in lexicographic byte order before verification, so the client must also sort before signing.
+
+## Response — success (200, partial-success)
+
+Returns `200 Success` even when individual renames fail — inspect the `failures` array.
+
+```json
+{
+  "Success": {
+    "status":        "ok",
+    "renamed_count": 2,
+    "successes": [
+      {
+        "old_path_hash":   [ /* 32 bytes */ ],
+        "new_path_hash":   [ /* 32 bytes */ ],
+        "new_revision_id": [ /* 32 bytes — server-assigned */ ],
+        "new_revision_seq": 5
+      }
+    ],
+    "failures": [
+      {
+        "old_path_hash": [ /* 32 bytes */ ],
+        "reason":        "revision_mismatch"
+      }
+    ]
+  }
+}
+```
+
+| Field | Meaning |
+|---|---|
+| `renamed_count` | Entries that succeeded (`successes.len()`) |
+| `successes[]` | Per-rename result with the new server-assigned `revision_id` + `revision_seq` |
+| `failures[]` | Per-rename failure with the offending `old_path_hash` and a `reason` code |
+
+### Known failure `reason` codes
+
+| `reason` | Meaning |
+|---|---|
+| `not_found` | No row at `old_path_hash` for this `(ss58, folder)` |
+| `target_exists` | A row already exists at `new_path_hash` — pick a different target or delete the existing one first |
+| `revision_mismatch` | `base_revision_id` does not match the current row's revision — re-fetch state and retry this entry |
+| `database_error` | Transient per-entry DB failure |
+
+## Response — errors (non-200)
+
+Only request-level failures produce an `Error` envelope:
+
+| Status | `error` code | Cause |
+|---|---|---|
+| `400` | `invalid_manifest` / `batch_too_large` | Body malformed, signature verification failed, or too many entries |
+| `401` | `unauthorized` | Missing / bad bearer token |
+| `403` | `forbidden` | Token resolves to a different SS58 than `ss58_address` |
+
+## Example
+
+```bash
+curl -X POST "$SERVER/rename_files" \
+  -H "Authorization: Bearer $SS58" \
+  -H "Content-Type: application/json" \
+  -d @rename_batch.json
+```
+
+(Constructing `rename_batch.json` requires computing the signature locally — the exact format is the canonical text above, signed with the user's Ed25519 key.)
+
+## Notes
+
+- The signature covers the `(old → new)` path-hash pairs only. `new_encrypted_path`, `new_file_name`, and `new_relative_path` are **not** signed — they are metadata the server accepts on trust once the rename pair check passes.
+- Because each rename carries its own `base_revision_id`, entries in the same batch may be independently accepted or rejected. The rest of the batch is unaffected.
+- For a simple "move one file" the batch is allowed to have exactly one entry. There is no single-rename variant.
+- After a successful rename, the file's `revision_seq` increments and its `revision_id` changes. Store the `new_revision_id` from the response for the next write.

--- a/docs/hcfs/api/s3-gateway.md
+++ b/docs/hcfs/api/s3-gateway.md
@@ -1,0 +1,173 @@
+---
+id: s3-gateway
+title: S3-compatible gateway
+sidebar_label: S3 Gateway
+slug: /hcfs/api/s3-gateway
+---
+
+# S3-compatible gateway
+
+Three endpoints that let any S3 SDK (or any plain multipart client) upload, download, and delete files through HCFS without implementing the native manifest + client-side encryption flow.
+
+**These paths are not end-to-end encrypted.** The server holds the plaintext of every file uploaded through the gateway. Use the gateway when the client environment cannot hold keys; use the [native HCFS path](./upload.md) otherwise.
+
+The gateway and the native path share the same `/upload` URL — the server inspects the first multipart field to decide which handler to dispatch.
+
+---
+
+## `POST /upload` {#post-upload}
+
+Upload a plain file. The server hashes the content, derives `path_hash` from the filename, and writes a `file_records` row.
+
+### Authentication
+
+`Authorization: Bearer <token>`. The token's resolved SS58 must match the `account_ss58` field in the request body. See [`auth.md`](./auth.md).
+
+### Request
+
+```
+POST /upload
+Content-Type: multipart/form-data; boundary=<boundary>
+Authorization: Bearer <token>
+```
+
+The **first** multipart field must be `account_ss58`. (This is the signal the server uses to route to the S3 handler rather than the HCFS native handler.) The `file` field follows.
+
+| Field | Content-Type | Body |
+|---|---|---|
+| `account_ss58` (first) | `text/plain` | The uploader's SS58 address |
+| `file` (second) | `application/octet-stream` | Raw file bytes — the server derives `path_hash` from the field filename |
+
+### Response — success (200)
+
+```json
+{
+  "Success": {
+    "file_id":   "<64-char hex>",
+    "upload_id": "<opaque>",
+    "timestamp": 1713139200
+  }
+}
+```
+
+### Response — errors
+
+| Status | `error` code | Cause |
+|---|---|---|
+| `400` | `invalid_manifest` / `missing_field` | First field isn't `account_ss58`, or the `file` field is missing |
+| `401` | `unauthorized` | Missing / bad bearer token |
+| `403` | `forbidden` | Token resolves to a different SS58 than `account_ss58` |
+| `500` | `database_error`, `storage_inconsistency` | Transient |
+
+### Example
+
+```bash
+curl -X POST "$SERVER/upload" \
+  -H "Authorization: Bearer $SS58" \
+  -F "account_ss58=$SS58" \
+  -F "file=@/path/to/document.pdf"
+```
+
+---
+
+## `GET /download/{ss58}/{file_id}` {#get-downloadss58file_id}
+
+Stream a file without folder scope. This is the gateway counterpart to the folder-scoped native [`/download`](./download.md) endpoint.
+
+### Authentication
+
+`Authorization: Bearer <token>` matching `{ss58}`.
+
+### Request
+
+```
+GET /download/{ss58}/{file_id}
+Authorization: Bearer <token>
+Range: bytes=<start>-<end>    # optional
+```
+
+### Response
+
+| Status | Meaning |
+|---|---|
+| `200 OK` | Full file returned |
+| `206 Partial Content` | Range request honored |
+
+Response headers mirror the native download: `Content-Length`, `X-Size-Bytes`, `X-Revision-Id`, `X-Revision-Seq`, `X-File-Id`, `X-Ss58-Address`, `Accept-Ranges`, `Content-Range`.
+
+The body is raw file bytes (the server stored the plaintext directly — no HCFS chunked envelope).
+
+### Response — errors
+
+| Status | `error` code | Cause |
+|---|---|---|
+| `400` | `invalid_file_id` | Not valid 64-char hex |
+| `401` | `unauthorized` | Missing / bad bearer token |
+| `403` | `forbidden` | Token resolves to a different SS58 than `{ss58}` |
+| `404` | `not_found` | No such file |
+| `500` | `storage_inconsistency` | Metadata row exists but blob is missing |
+
+### Example
+
+```bash
+curl -H "Authorization: Bearer $SS58" \
+     -o "document.pdf" \
+     "$SERVER/download/$SS58/$FILE_ID"
+```
+
+---
+
+## `DELETE /delete/{ss58}/{file_id}` {#delete-deletess58file_id}
+
+Remove a file uploaded via the gateway.
+
+### Authentication
+
+`Authorization: Bearer <token>` matching `{ss58}`.
+
+### Request
+
+```
+DELETE /delete/{ss58}/{file_id}
+Authorization: Bearer <token>
+```
+
+### Response — success (200)
+
+```json
+{
+  "Success": {
+    "status":       "deleted",
+    "file_id":      "<64-char hex>",
+    "ss58_address": "5Grw...",
+    "folder_hash":  ""
+  }
+}
+```
+
+`folder_hash` is empty for gateway-owned files.
+
+### Response — errors
+
+| Status | `error` code | Cause |
+|---|---|---|
+| `400` | `invalid_file_id` | Not valid hex |
+| `401` | `unauthorized` | Missing / bad bearer token |
+| `403` | `forbidden` | SS58 mismatch |
+| `404` | `not_found` | No such file |
+
+### Example
+
+```bash
+curl -X DELETE \
+     -H "Authorization: Bearer $SS58" \
+     "$SERVER/delete/$SS58/$FILE_ID"
+```
+
+---
+
+## Notes
+
+- Files uploaded through the gateway are listed by [`/get_state`](./get-state.md) alongside native uploads — the two paths share the `file_records` table.
+- Because the server holds plaintext for gateway uploads, do not use this path for anything the user would not put on a conventional S3 bucket.
+- If you need the full end-to-end-encrypted experience (server never sees plaintext, client-side key management), use the native [`/upload`](./upload.md) flow instead.

--- a/docs/hcfs/api/search-files.md
+++ b/docs/hcfs/api/search-files.md
@@ -1,0 +1,135 @@
+---
+id: search-files
+title: GET /search_files/{ss58}
+sidebar_label: GET /search_files
+slug: /hcfs/api/search-files
+---
+
+# `GET /search_files/{ss58}`
+
+Cross-folder file search with server-side filtering, sorting, and pagination. Shipped in PR #143. Use this instead of `GET /list_folders` + per-folder `GET /get_state` when you need to search or filter — client-side filtering against a paginated `get_state` response will miss matches on later pages.
+
+## Authentication
+
+Same as `/get_state`: `Authorization: Bearer <token>` where the token is tied to the `{ss58_address}` in the path. `X-Billing-Bypass: <token>` if your environment requires it. Requests authorized as a different ss58 get **403**.
+
+## Query parameters
+
+All are optional. Filters that are set combine with **AND**.
+
+| Name         | Type    | Default       | Notes |
+|--------------|---------|---------------|-------|
+| `q`          | string  | —             | Case-insensitive substring match against `file_name` (falls back to `relative_path` if `file_name` is null). Max 256 chars; longer returns 400 `q_too_long`. |
+| `file_type`  | string  | —             | Either a category or an explicit extension like `.png`. See [categories](#file_type-categories). Unknown value returns 400 `invalid_file_type`. |
+| `size_min`   | number  | —             | Bytes, inclusive (`size_bytes >= size_min`). |
+| `size_max`   | number  | —             | Bytes, inclusive (`size_bytes <= size_max`). |
+| `date_from`  | number  | —             | Unix seconds, inclusive (`created_at >= date_from`). |
+| `date_to`    | number  | —             | Unix seconds, inclusive (`created_at <= date_to`). |
+| `offset`     | number  | `0`           | |
+| `limit`      | number  | `25`          | Capped at 10000. |
+| `sort_by`    | string  | `created_at`  | One of: `file_name`, `size_bytes`, `created_at`, `updated_at`. Unknown values silently fall back to the default. |
+| `sort_order` | string  | `desc`        | `asc` or `desc` (case-insensitive). Unknown values silently fall back to `desc`. |
+
+### `file_type` categories
+
+| Category    | Extensions |
+|-------------|------------|
+| `image`     | `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.svg`, `.bmp`, `.ico`, `.tiff` |
+| `video`     | `.mp4`, `.mov`, `.avi`, `.mkv`, `.webm`, `.flv`, `.wmv` |
+| `audio`     | `.mp3`, `.wav`, `.ogg`, `.flac`, `.aac`, `.m4a`, `.wma` |
+| `document`  | `.doc`, `.docx`, `.xls`, `.xlsx`, `.ppt`, `.pptx`, `.txt`, `.csv`, `.rtf` |
+| `pdf`       | `.pdf` |
+| `archive`   | `.zip`, `.rar`, `.7z`, `.tar`, `.gz`, `.bz2` |
+| `code`      | `.js`, `.ts`, `.py`, `.rs`, `.go`, `.java`, `.c`, `.cpp`, `.html`, `.css`, `.json` |
+
+`file_type=other` returns **400** — the spec listed it but it has no defined extensions on the server side, so rejecting it early prevents a silent "returns every row" bug.
+
+Explicit extensions (`file_type=.png`) match files whose name ends with that extension, case-insensitively.
+
+## Response — success (200)
+
+```json
+{
+  "Success": {
+    "ss58_address": "5Grw...",
+    "files": [
+      {
+        "folder_hash": "abc1234567890def",
+        "folder_label": "My Documents",
+        "path_hash": [ /* 32 bytes */ ],
+        "salted_hash": [ /* 32 bytes */ ],
+        "size_bytes": 1048576,
+        "revision_seq": 1,
+        "revision_id": [ /* 32 bytes */ ],
+        "encrypted_path": [ /* variable length ciphertext */ ],
+        "file_name": "report.pdf",
+        "relative_path": "Work/report.pdf",
+        "arion_hash": "Qm...",
+        "chunk_hashes": ["Qm...", "Qm..."],
+        "created_at": 1713139200,
+        "updated_at": 1713139200
+      }
+    ],
+    "total_count": 142,
+    "has_more": true,
+    "offset": 0,
+    "limit": 25
+  }
+}
+```
+
+### Hit shape notes
+
+- `folder_hash` and `folder_label` are added by this endpoint — they tell you which folder each result belongs to so you can render breadcrumbs or group by folder without a second lookup.
+- `folder_label` is `""` if the folder was never registered via `POST /register_folder` (legacy rows or unregistered test data).
+- Every other field is identical to what `/get_state` returns per file (`RemoteFileEntry` shape, flattened onto the top level — no nested `file: {}` object).
+- `relative_path` is plaintext. If you need the parent directory path, strip the filename client-side: `relative_path.rsplit('/', 1).first()`.
+- `arion_hash` and `chunk_hashes` are `null` when Arion storage metadata is unavailable for the row; `file_name` / `relative_path` are `null` for pre-backfill rows.
+
+## Response — errors
+
+All errors use the shared `NetworkResponse::Error` envelope:
+
+```json
+{ "Error": { "error": "<code>", "message": "<human-readable>" } }
+```
+
+| Status | `error` code          | When                                                           |
+|--------|-----------------------|----------------------------------------------------------------|
+| 400    | `invalid_file_type`   | Unknown category or `other` or malformed extension.            |
+| 400    | `q_too_long`          | `q` exceeds 256 characters.                                    |
+| 400    | `invalid_user_id`     | `ss58_address` is empty, over 256 bytes, or contains `%` / `\`.|
+| 401    | `unauthorized`        | Missing / invalid `Authorization` header.                      |
+| 403    | `forbidden`           | Token valid but does not match the path `ss58_address`.        |
+| 404    | `not_found`           | Resource missing (reserved; not produced by the current read path). |
+| 409    | `conflict`            | Write conflict (reserved; not produced by the current read path).   |
+| 500    | `database_error`      | Server-side DB failure. The body is generic; check server logs.|
+
+## Pagination
+
+- Send `offset` + `limit`. Server returns `total_count` (across all pages, not just this page) and `has_more`.
+- `has_more` is `true` iff `offset + returned_count < total_count`.
+- Results are stably sorted by the chosen column plus `path_hash` as a tiebreaker, so paging through a dataset with duplicate sort values doesn't drop or repeat rows.
+
+## Examples
+
+```
+GET /search_files/{ss58}?q=report&offset=0&limit=25
+GET /search_files/{ss58}?file_type=image&size_min=1048576
+GET /search_files/{ss58}?date_from=1710000000&date_to=1713139200&sort_by=size_bytes&sort_order=desc
+GET /search_files/{ss58}?q=photo&file_type=image&size_max=5242880&date_from=1710000000
+```
+
+## Caveats
+
+- **Pre-backfill rows.** Rows where both `file_name` AND `relative_path` are null (uploaded before relative-path support) are invisible to `q` and `file_type` filters. They will still appear when no name/type filter is set. Same caveat applies to `/browse`.
+- **Substring search performance.** `q` uses `ILIKE '%...%'` which does not hit the existing prefix index, so very large folders may be slow under deep substring searches. Fine at current scale; if your UI shows noticeable latency on large libraries, ping backend about adding a `pg_trgm` index.
+- **`list_folders` and `get_state` are unchanged.** This endpoint is additive; existing flows keep working.
+
+## Source
+
+- Plan: `docs/plans/2026-04-20-hcfs-search-files-endpoint.md`
+- Handler: `hcfs-server/src/handlers/search.rs`
+- DB method: `hcfs-server/src/database.rs` (`HcfsStore::search_user_files`)
+- Types: `hcfs-shared/src/network.rs` (`SearchFilesQuery`, `SearchFileHit`, `SearchFilesResult`)
+- PR: [#143](https://github.com/thenervelab/hcfs/pull/143)

--- a/docs/hcfs/api/upload-session.md
+++ b/docs/hcfs/api/upload-session.md
@@ -1,0 +1,273 @@
+---
+id: upload-session
+title: Chunked upload session
+sidebar_label: Chunked upload session
+slug: /hcfs/api/upload-session
+---
+
+# Chunked upload session
+
+Five endpoints that implement a resumable, parallel-friendly upload flow for large files. The client opens a session, uploads chunks in any order (optionally in parallel), finalizes to commit the assembled file, or deletes to abort.
+
+Use this instead of the single-shot [`/upload`](./upload.md) for anything above a few tens of MiB — the single-shot path buffers the full multipart body and fails entirely on network blips.
+
+## Lifecycle
+
+```
+POST   /upload/session                           → session_id
+PUT    /upload/session/{id}/chunk/{index}        (repeat per chunk)
+GET    /upload/session/{id}/status               (optional; resume after a crash)
+POST   /upload/session/{id}/finalize             → revision_id
+DELETE /upload/session/{id}                      (optional; abort)
+```
+
+## Authentication
+
+Every endpoint requires `Authorization: Bearer <token>` matching the session owner's SS58 address. See [`auth.md`](./auth.md). The session owner is fixed at creation time from `manifest.ss58_address`.
+
+---
+
+## `POST /upload/session` {#post-uploadsession}
+
+Open a new chunked upload session. The request carries the full `Manifest` for the target file (same shape as for a single-shot upload — see [`upload.md`](./upload.md#manifest-schema)) plus chunk-layout metadata.
+
+### Request
+
+```
+POST /upload/session
+Content-Type:  application/json
+Authorization: Bearer <token>
+```
+
+```json
+{
+  "manifest":        { /* full Manifest — see upload.md */ },
+  "chunk_count":     64,
+  "chunk_size":      1048576,
+  "ciphertext_size": 67108864
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `manifest` | object | Full signed manifest for the file being uploaded |
+| `chunk_count` | `u32` | Number of chunks the client intends to upload |
+| `chunk_size` | `u64` | Bytes per chunk (last chunk may be smaller). Each chunk ≤ 16 MiB. |
+| `ciphertext_size` | `u64` | Total ciphertext size (base nonce + framing + all chunks) |
+
+### Response — success (200)
+
+```json
+{
+  "Success": {
+    "session_id": "<opaque string>",
+    "expires_at": 1713225600
+  }
+}
+```
+
+Store `session_id` — every subsequent endpoint needs it. Sessions expire at `expires_at` (Unix seconds); uploading a chunk or calling `status` refreshes the expiry.
+
+### Errors
+
+| Status | `error` code | Cause |
+|---|---|---|
+| `400` | `invalid_manifest` | Manifest signature invalid, or `chunk_count` / `chunk_size` inconsistent with `ciphertext_size` |
+| `401` | `unauthorized` | Missing / bad bearer token |
+| `403` | `forbidden` | Token resolves to a different SS58 than `manifest.ss58_address` |
+
+### Example
+
+```bash
+curl -X POST "$SERVER/upload/session" \
+  -H "Authorization: Bearer $SS58" \
+  -H "Content-Type: application/json" \
+  -d @create_session.json
+```
+
+---
+
+## `PUT /upload/session/{session_id}/chunk/{chunk_index}` {#put-uploadsessionidchunkindex}
+
+Upload one chunk of ciphertext. Chunks may be uploaded in any order and in parallel. Re-uploading a chunk is idempotent (last write wins, same index).
+
+### Request
+
+```
+PUT /upload/session/{session_id}/chunk/{chunk_index}
+Content-Type:  application/octet-stream
+Authorization: Bearer <token>
+```
+
+| Parameter | Format | Notes |
+|---|---|---|
+| `session_id` | string | Returned by `POST /upload/session` |
+| `chunk_index` | `u32` | 0-based chunk index. Must be `< chunk_count` from the session. |
+
+Body: raw chunk bytes. ≤ 16 MiB.
+
+### Response — success (200)
+
+```json
+{ "Success": { "chunk_index": 7 } }
+```
+
+### Errors
+
+| Status | `error` code | Cause |
+|---|---|---|
+| `400` | `invalid_manifest` | Chunk size exceeds 16 MiB, or `chunk_index ≥ chunk_count` |
+| `401` | `unauthorized` | Missing / bad bearer token |
+| `403` | `forbidden` | Token does not own the session |
+| `404` | `not_found` | No such session (never existed, or expired) |
+
+### Example
+
+```bash
+curl -X PUT "$SERVER/upload/session/$SESSION_ID/chunk/7" \
+  -H "Authorization: Bearer $SS58" \
+  -H "Content-Type: application/octet-stream" \
+  --data-binary "@chunk-7.bin"
+```
+
+---
+
+## `GET /upload/session/{session_id}/status` {#get-uploadsessionidstatus}
+
+Inspect session progress — which chunks have arrived, which are still missing, and whether the session is ready to finalize. Use this to resume after a client restart.
+
+### Request
+
+```
+GET /upload/session/{session_id}/status
+Authorization: Bearer <token>
+```
+
+### Response — success (200)
+
+```json
+{
+  "Success": {
+    "session_id":      "<same as URL>",
+    "state":           "receiving",
+    "total_chunks":    64,
+    "chunks_received": [0, 1, 2, 3, 5, 6, 8 /* ... */],
+    "expires_at":      1713225600,
+    "ciphertext_hash": "<BLAKE3 hex from manifest>"
+  }
+}
+```
+
+| Field | Meaning |
+|---|---|
+| `state` | `"receiving"` or `"finalized"`. Clients should only call `finalize` when `chunks_received.len() == total_chunks`. |
+| `chunks_received` | List of chunk indices uploaded so far. To resume, compute `missing = { 0..total_chunks } - chunks_received` and upload those. |
+| `expires_at` | Unix seconds when the session will be garbage-collected if idle |
+| `ciphertext_hash` | Mirror of the session's `Manifest.ciphertext_hash`. Handy when resuming without access to the original manifest — lets you confirm you have the right session. |
+
+### Errors
+
+| Status | `error` code | Cause |
+|---|---|---|
+| `401` | `unauthorized` | Missing / bad bearer token |
+| `403` | `forbidden` | Token does not own the session |
+| `404` | `not_found` | No such session |
+
+### Example
+
+```bash
+curl -H "Authorization: Bearer $SS58" \
+     "$SERVER/upload/session/$SESSION_ID/status"
+```
+
+---
+
+## `POST /upload/session/{session_id}/finalize` {#post-uploadsessionidfinalize}
+
+Assemble the uploaded chunks into the final ciphertext, verify the BLAKE3 hash against the session manifest, persist to storage, and write the `file_records` row. After this returns `200 Success`, the file behaves identically to one uploaded via the single-shot [`/upload`](./upload.md) endpoint.
+
+### Request
+
+```
+POST /upload/session/{session_id}/finalize
+Authorization: Bearer <token>
+```
+
+No body.
+
+### Response — success (200)
+
+Same shape as [`/upload`](./upload.md#response--success-200) — a `UploadResult` with the server-assigned `revision_id`.
+
+```json
+{
+  "Success": {
+    "upload_id":   "<opaque>",
+    "timestamp":   1713139200,
+    "revision_id": [ /* 32 bytes */ ],
+    "created_at":  1713139200,
+    "updated_at":  1713139200
+  }
+}
+```
+
+### Errors
+
+| Status | `error` code | Cause |
+|---|---|---|
+| `400` | `invalid_manifest` | Not all chunks have been uploaded, or assembled `ciphertext_hash` does not match the manifest |
+| `401` | `unauthorized` | Missing / bad bearer token |
+| `403` | `forbidden` | Token does not own the session |
+| `404` | `not_found` | No such session |
+| `409` | `conflict` / `upload_conflict` | `base_revision_id` does not match current — handle exactly as for a single-shot upload |
+| `500` | `database_error`, `storage_inconsistency` | Transient |
+
+### Example
+
+```bash
+curl -X POST "$SERVER/upload/session/$SESSION_ID/finalize" \
+  -H "Authorization: Bearer $SS58"
+```
+
+---
+
+## `DELETE /upload/session/{session_id}` {#delete-uploadsessionid}
+
+Abort a session and release its temporary storage. Safe to call at any point; idempotent.
+
+### Request
+
+```
+DELETE /upload/session/{session_id}
+Authorization: Bearer <token>
+```
+
+### Response — success (200)
+
+```json
+{ "Success": { "deleted": true } }
+```
+
+### Errors
+
+| Status | `error` code | Cause |
+|---|---|---|
+| `401` | `unauthorized` | Missing / bad bearer token |
+| `403` | `forbidden` | Token does not own the session |
+| `404` | `not_found` | No such session (already deleted, or never existed) |
+
+### Example
+
+```bash
+curl -X DELETE "$SERVER/upload/session/$SESSION_ID" \
+  -H "Authorization: Bearer $SS58"
+```
+
+---
+
+## Notes
+
+- Sessions are owned by the SS58 that created them. A different user cannot read, extend, finalize, or delete a session even if they somehow learn the `session_id`.
+- Expired sessions and their chunk data are garbage-collected by a background worker. Treat `404 not_found` on a session you believe you created as "your session expired — open a new one and re-upload".
+- There is no per-chunk signature. The server verifies the whole assembled ciphertext against `manifest.ciphertext_hash` at finalize time — a chunk that is altered in transit will cause `finalize` to fail with `invalid_manifest`, not the individual `PUT`.
+- Parallel chunk upload is supported and encouraged — the server accepts chunks independently. Bound your client-side concurrency to avoid self-DoS.

--- a/docs/hcfs/api/upload.md
+++ b/docs/hcfs/api/upload.md
@@ -1,0 +1,135 @@
+---
+id: upload
+title: POST /upload — HCFS native upload
+sidebar_label: POST /upload
+slug: /hcfs/api/upload
+---
+
+# POST /upload — HCFS native upload
+
+Upload one end-to-end encrypted file. The request body is a `multipart/form-data` payload with a signed `manifest` field (JSON) followed by a `ciphertext` field (binary). The server authenticates the manifest signature, enforces optimistic concurrency on revisions, streams the ciphertext to storage, and writes a `file_records` row.
+
+For the S3-compatible gateway variant (plain file upload without a manifest or client-side encryption), see [`s3-gateway.md`](./s3-gateway.md).
+
+## Authentication
+
+`Authorization: Bearer <token>`. The token's resolved SS58 must match `manifest.ss58_address`. See [`auth.md`](./auth.md).
+
+## Request
+
+### Method and path
+
+```
+POST /upload
+```
+
+### Headers
+
+```
+Authorization: Bearer <token>
+Content-Type:  multipart/form-data; boundary=<boundary>
+```
+
+### Body — multipart form
+
+The first multipart field **must** be named `manifest`; the server peeks the field name to dispatch the handler.
+
+| Field | Content-Type | Body |
+|---|---|---|
+| `manifest` (first) | `application/json` | JSON-serialized `Manifest` — see below |
+| `ciphertext` (second) | `application/octet-stream` | The chunked-encrypted file blob |
+
+### Manifest schema
+
+Authoritative source: `hcfs-shared/src/network.rs::Manifest`.
+
+| Field | Type | Notes |
+|---|---|---|
+| `ss58_address` | `string` | The user's SS58 (accepts alias `user_id`) |
+| `folder_hash` | `string` | 16-char hex — first 16 chars of `SHA-256(folder_label)` |
+| `ciphertext_hash` | `string` | BLAKE3 hex of the ciphertext blob |
+| `size_bytes` | `u64` | **Plaintext** size in bytes |
+| `timestamp` | `i64` | Client-supplied Unix seconds |
+| `signature` | `[u8; 64]` | Ed25519 signature — see below |
+| `signing_key` | `[u8; 32]` | Ed25519 public verifying key |
+| `path_hash` | `[u8; 32]` | `BLAKE3(relative_path.utf8_bytes)` |
+| `salted_hash` | `[u8; 32]` | `BLAKE3(ss58_address ‖ plaintext_bytes)` |
+| `revision_seq` | `u64` | Monotonic — strictly greater than the file's current `revision_seq`. `1` for new files. |
+| `base_revision_id` | `[u8; 32] \| null` | Current revision the client believed it was modifying. `null` for new files. |
+| `encrypted_path` | `Vec<u8>` | Chunked-encrypted relative path (may be empty) |
+| `file_name` | `string \| null` | Plaintext filename — improves download progress UX |
+| `relative_path` | `string \| null` | Plaintext relative path — enables `/browse` and `/search_files` |
+
+### Signature scheme
+
+The signature does **not** cover the full manifest JSON. It covers a fixed-format Terms-of-Service declaration containing the ciphertext hash:
+
+```
+text = "I here by declare that the file with hash {ciphertext_hash} that i am uploading is in par with the ToS of the provider"
+signature = Ed25519::sign(signing_key, text.as_bytes())
+```
+
+The integrity of the other manifest fields is enforced at lookup / sync time via `salted_hash` comparisons and the server's independent BLAKE3 recomputation of the ciphertext.
+
+### Ciphertext wire format
+
+The `ciphertext` multipart field is a framed chunked blob:
+
+```
+[base_nonce: 24 bytes]
+[chunk_count: u32 little-endian]
+for each chunk i in 0..chunk_count:
+  [chunk_len: u32 LE]   = ciphertext_bytes_len + 16 (Poly1305 tag)
+  [ciphertext_bytes]
+  [auth_tag: 16 bytes]
+```
+
+Per-chunk nonce is `base_nonce[..8] XOR chunk_index.to_le_bytes()` (XOR against the first 8 bytes; remaining 16 bytes unchanged). Chunk size is 256 KiB. Zero-byte files produce `chunk_count = 1` with a single empty-plaintext frame.
+
+`manifest.ciphertext_hash` is `BLAKE3(entire blob).hex()` — the server re-computes and rejects mismatches.
+
+## Response — success (200)
+
+```json
+{
+  "Success": {
+    "upload_id":   "<opaque>",
+    "timestamp":   1713139200,
+    "revision_id": [ /* 32 bytes — the new revision */ ],
+    "created_at":  1713139200,
+    "updated_at":  1713139200
+  }
+}
+```
+
+`revision_id` is server-assigned. Store it so the next write to this file can send it as `base_revision_id`.
+
+## Response — errors
+
+Shared envelope shape in [`errors.md`](./errors.md).
+
+| Status | `error` code | Cause |
+|---|---|---|
+| `400` | `invalid_manifest` | Manifest JSON malformed, signature invalid, or required field missing |
+| `400` | `stale_sequence` | `revision_seq` is not strictly greater than the current row's |
+| `401` | `unauthorized` | Missing / bad bearer token |
+| `403` | `forbidden` | Token resolves to a different SS58 than `manifest.ss58_address` |
+| `409` | `conflict` / `upload_conflict` | `base_revision_id` does not match current. Envelope carries `current_revision_id` + `current_revision_seq`. |
+| `500` | `database_error`, `storage_inconsistency` | Transient — retry with backoff |
+
+## Example
+
+```bash
+curl -X POST "$SERVER/upload" \
+  -H "Authorization: Bearer $SS58" \
+  -F "manifest=@manifest.json;type=application/json" \
+  -F "ciphertext=@file.enc;type=application/octet-stream"
+```
+
+Field order matters: the `manifest` field must be first. Tools like `curl` send `-F` flags in order.
+
+## Notes
+
+- Large files should use the chunked upload session flow — see [`upload-session.md`](./upload-session.md).
+- To discover a file's current `revision_id` before an update, list the folder via [`/get_state`](./get-state.md) and find the entry by `path_hash`.
+- For renames, prefer [`/rename_files`](./rename-files.md) over an upload at the new path + delete at the old one — the batch rename is atomic and does not re-upload ciphertext.

--- a/docs/hcfs/architecture-diagrams.md
+++ b/docs/hcfs/architecture-diagrams.md
@@ -1,0 +1,70 @@
+---
+id: architecture-diagrams
+title: HCFS Architecture Diagrams
+sidebar_label: Architecture Diagrams
+slug: /hcfs/architecture-diagrams
+---
+
+# HCFS Architecture Diagrams
+
+Three views of the HCFS system, each rendered as a standalone SVG. Click through for a crisp, zoomable render.
+
+| # | Diagram | What it shows |
+|---|---------|---------------|
+| 1 | [Overall architecture](/img/hcfs/diagrams/01-overall-architecture.svg) | Both client protocols (HCFS native + S3-compatible gateway), the axum server, and the Arion storage plane in one picture |
+| 2 | [Server ingestion (HCFS vs S3 gateway)](/img/hcfs/diagrams/02-server-ingestion.svg) | Side-by-side lanes of the two `/upload` paths, from request shape to FileRecord |
+| 3 | [Sync engine (three-tree)](/img/hcfs/diagrams/03-sync-engine.svg) | Input trees → `SyncPlan::build` → execution → outcome, with the full classification matrix |
+
+---
+
+## 1 · Overall architecture
+
+![HCFS overall architecture](/img/hcfs/diagrams/01-overall-architecture.svg)
+
+Native HCFS clients and S3-compatible gateway clients both terminate at the same axum server. The server peeks the first multipart field of `/upload` to dispatch. All ciphertext + metadata converges on the Arion storage gateway and a PostgreSQL row in `file_records`. Billing pushes run as fire-and-forget Tokio tasks.
+
+Sources: `hcfs-server/src/handlers/upload.rs`, `hcfs-server/src/state.rs`, `hcfs-server/src/storage.rs`.
+
+---
+
+## 2 · Server ingestion — HCFS vs S3 gateway
+
+![Server ingestion](/img/hcfs/diagrams/02-server-ingestion.svg)
+
+Both clients hit `POST /upload`. The first multipart field decides the path:
+
+- **`"manifest"` → `handle_hcfs_upload`** — signed manifest, client-side encryption, `path_hash` and `salted_hash` computed on the client. Server authorizes with `authorize_hcfs_upload`, checks revision CAS, streams the ciphertext field to storage.
+- **`"account_ss58"` → `handle_s3_upload`** — plain multipart with a cleartext filename. Server authorizes with `authorize_s3_upload` (token SS58 must match account), streams the file to storage, then `build_s3_file_record` derives `path_hash` from the filename and `persist_s3_record` writes the row.
+
+After the handler split, both paths converge on the shared `StorageBackend.upload` + `upsert_file_checked` + async billing tail. Download URLs differ too: HCFS uses `/download/{ss58}/{folder_hash}/{file_id}`; S3 gateway clients use `/download/{ss58}/{file_id}` (see `download_no_folder` in `hcfs-server/src/handlers/file.rs`).
+
+Sources: `hcfs-server/src/handlers/upload.rs`, `hcfs-server/src/handlers/helpers.rs`, `hcfs-server/src/storage.rs`, `hcfs-server/src/database.rs`.
+
+---
+
+## 3 · Sync engine (three-tree)
+
+![Sync engine](/img/hcfs/diagrams/03-sync-engine.svg)
+
+`hcfs-client` keeps three `FileTree`s — **local** (scanned from disk), **remote** (fetched via `HcfsClient::get_state`), and **synced** (last known reconciled state, persisted in `.hippius/sync_state.json`). `SyncPlan::build` classifies every `FileId` via the matrix in the diagram and sorts it into action buckets. A second pass, `extract_renames`, promotes matching upload/delete pairs into `RenameOp`s using Tier-1 watcher hints first, then Tier-2 content-hash pairing.
+
+Execution is driven by `Drive::execute_sync_plan`:
+
+1. Resolve any conflicts via the caller-supplied `conflict_resolver` callback (`KeepLocal`, `AcceptRemote`, `KeepBoth`, `Skip`).
+2. Run uploads and downloads concurrently (bounded; cancellable via `CancellationToken`).
+3. Run renames (batch `POST /rename_files`), then serial local/remote deletes.
+4. Fold successes into a new `synced` tree, persist atomically, and hand the `SyncOutcome` back to `SyncRunner` for activity-log and health tracking.
+
+Sources: `hcfs-client/src/sync/plan.rs`, `hcfs-client/src/sync/conflict.rs`, `hcfs-client/src/sync/rename.rs`, `hcfs-client/src/drive/sync_flow.rs`, `hcfs-client/src/engine/runner.rs`.
+
+---
+
+## Editing the diagrams
+
+These are hand-authored SVG files — open them in any editor (VS Code renders them inline) or a vector tool like Figma/Inkscape. The styling is centralized in each file's `<defs><style>` block:
+
+- `--fill` families: `#eff6ff` (HCFS/client trust), `#ecfeff` (S3 gateway ingress), `#fff7ed` (server), `#f5f3ff` (Arion storage), `#fee2e2` (conflicts).
+- Arrows: solid `#374151` for synchronous flow, dashed `#7c3aed` for fire-and-forget or async side effects.
+- Fonts use system stacks so GitHub / browsers render consistently without external assets.
+
+If you regenerate these from another source (draw.io, D2, etc.), keep the filenames stable so the links above don't break.

--- a/docs/hcfs/integration-guide.md
+++ b/docs/hcfs/integration-guide.md
@@ -1,0 +1,561 @@
+---
+id: integration-guide
+title: HCFS Integration Guide
+sidebar_label: Integration Guide
+slug: /hcfs/integration-guide
+---
+
+# HCFS Integration Guide
+
+How to talk to HCFS from your own application — desktop, browser, or anything else. This is a guide for *integrators*: people building a client on top of HCFS, not people changing HCFS itself.
+
+---
+
+## 1. Mental Model
+
+HCFS is a sync system with a strict rule: **the server stores ciphertext and metadata, and never holds a key that can decrypt it.** Encryption, decryption, and signing all happen on your client. If a user loses their 24-word mnemonic, their data is unrecoverable — by design.
+
+This shapes every integration choice. You are not building "a UI on top of a file API." You are building **a key-holding agent** that happens to talk to a file API. Three things follow:
+
+- **Identity is a keypair, not a username.** A user is identified by an SS58 address derived (via Substrate's standard format, prefix `42`) from an Ed25519 public key, which is itself derived from a BIP-39 mnemonic. There is no password reset flow on the server side. One master mnemonic can produce many *folder-scoped* identities through deterministic derivation (§3.1, §6.1) — the same person can have several `ss58_address`/`folder_hash` namespaces on the same server.
+
+- **The server is the source of truth, but only for ciphertext.** It tracks revisions, resolves write races (optimistic concurrency via `base_revision_id`), and serves any client who can present a valid token. Plaintext paths, filenames, and file content never reach it.
+
+- **Sync is a three-tree merge, not a one-way push.** Every change is classified by comparing **local** (disk), **remote** (server), and **synced** (last reconciled state). This is what makes multi-device editing safe — and what makes "just upload everything on save" the wrong mental model.
+
+Your job, regardless of stack, is: hold the keys, drive the merge, and stream ciphertext over HTTP. Everything else in this guide is detail on those three responsibilities.
+
+---
+
+## 2. Pick Your Integration Path
+
+Four paths exist. Pick by the language you're already writing your UI in — not by what feels closest to HCFS.
+
+| If your app is… | Use | Why |
+|---|---|---|
+| Tauri (Rust backend) or any native Rust UI (egui, slint) | **`hcfs-client` crate** | Direct access to `Drive`, the sync engine, and progress callbacks. Same code path as the reference CLI. |
+| Electron, web-based Tauri frontend, or any browser/Node app | **`@hippius/hcfs-client-wasm`** *(crypto only)* + your own HTTP/sync layer | Real XChaCha20/Ed25519 in the renderer — no shipping a Rust binary alongside your JS. The WASM crate exposes primitives, **not** a full sync engine. |
+| Python tooling, scripts, automation | **`hcfs-client` with `python` feature** (`pyo3` bindings) | One-line install via `maturin`, same `Drive` semantics. |
+| Swift, Kotlin, Go, .NET, anything else | **Raw HTTP + crypto spec** (§6) | You re-implement the client side from the spec. Plan for it — this is real work, not a wrapper. |
+
+### How to choose for a desktop app specifically
+
+- **Default to Tauri + `hcfs-client`.** You get the full `Drive` API (init, unlock, stage, sync, conflict resolution) with one dependency. The reference CLI in `hcfs-client-cli/` is a complete working example — read it before you write anything new.
+- **Choose Electron + WASM only if** you already have an Electron codebase, or your team can't ship Rust. Crypto runs in the renderer process; you still need a TypeScript layer for the HTTP client, the three-tree state, and persistence.
+- **Avoid raw HTTP for desktop apps** unless you're targeting a platform with no Rust-to-binding story (e.g., a Swift-only macOS app where you want zero foreign code). Re-implementing BIP-39 → Ed25519 → XChaCha20 → manifest signing correctly is several weeks of work plus a test suite — most of which already exists in `hcfs-client`.
+
+### What you're signing up for, regardless of path
+
+Every path requires you to implement the same four responsibilities locally:
+
+1. Mnemonic generation, encryption-at-rest, and password-gated unlock.
+2. Per-file encryption with a fresh nonce, plus `path_hash` and `salted_hash` derivation.
+3. Manifest signing (Ed25519) and Bearer token construction.
+4. Three-tree state persistence between sync runs.
+
+The Rust crate and Python bindings do all four for you. The WASM crate covers (1) and (2). Raw HTTP gives you none of it.
+
+---
+
+## 3. Core Concepts
+
+Five concepts you must internalize. Skip these and the API will surprise you in production.
+
+### 3.1 Identity is derived, not assigned
+
+A user is a 24-word BIP-39 mnemonic. Everything else is derived deterministically. The desktop client supports a *per-folder* derivation so one master mnemonic produces multiple independent identities on the server:
+
+```
+master_mnemonic   →  master_seed (64 bytes, empty BIP-39 passphrase)
+folder_label      →  folder_hash = hex(SHA-256(label))[..16]
+                  →  folder_entropy = SHA-256(master_seed[..32] || label)
+                  →  folder_mnemonic = BIP-39::from_entropy(folder_entropy)
+                  →  folder_seed = folder_mnemonic.to_seed("")
+                  →  ed25519 signing key  (folder_seed[..32])
+                  →  xchacha20 encryption key (same 32 bytes — see §6.1)
+                  →  ss58_address = SS58(public_key, prefix=42)
+```
+
+The bearer token presented to the server is the SS58 address (the desktop client falls back to it when no explicit token is configured — `hcfs-client/src/drive/init.rs:67-78`). The mnemonic is stored on-disk encrypted with AES-256-GCM, gated behind a user password (PBKDF2 in the desktop client; Argon2id in the WASM crate — §6.2). The server never sees the mnemonic, the seed, or the password.
+
+### 3.2 Files are addressed by hash, not path
+
+The server has no concept of `/Documents/taxes/2026.pdf`. It knows only:
+
+- `path_hash = blake3(relative_path)` — the file's stable identifier across syncs
+- `salted_hash = blake3(user_id || plaintext)` — used for content equality checks during sync (cheaper than re-hashing nonces)
+- `file_id` — the hex form of `path_hash`, used in URLs
+
+Renaming a file changes its `path_hash` and is therefore a delete-plus-create on the server, then promoted to a `RenameOp` by the client's pairing pass (§7.1). **Plaintext paths never leave the client.** If you want browseable folder structures (`/browse`, `/search_files`), you must explicitly upload encrypted relative paths via [`POST /register_relative_paths`](./api/register-relative-paths.md).
+
+### 3.3 The three-tree sync model
+
+Every sync compares three snapshots:
+
+- **Local** — what's on disk right now (built by `scan_local_files`)
+- **Remote** — what the server holds (paginated `GET /get_state/{ss58}/{folder_hash}`)
+- **Synced** — the last reconciled state, persisted in `.hippius/sync_state.json`
+
+The classification matrix (A, B, C are distinct content hashes; `-` is "not present"):
+
+| Local | Remote | Synced | Action |
+|:-:|:-:|:-:|---|
+| A | A | A | Unchanged |
+| A | - | - | LocalCreate → upload |
+| - | A | - | RemoteCreate → download |
+| A | A | B | LocalModify → upload |
+| A | B | A | RemoteModify → download |
+| - | A | A | LocalDelete → remote delete |
+| A | - | A | RemoteDelete → local delete |
+| A | B | C | Conflict (ModifyModify) |
+| A | - | B | Conflict (ModifyDelete) |
+| - | A | B | Conflict (DeleteModify) |
+| A | B | - | Conflict (CreateCreate) |
+
+You must persist the synced tree atomically — losing it means the next sync sees every file as a `LocalCreate` and re-uploads everything.
+
+### 3.4 Server authority and optimistic concurrency
+
+Uploads carry `base_revision_id` (the revision the client thought it was modifying). The server compares it to the current revision and rejects mismatches with `409 Conflict`. New files send `base_revision_id = null` and get rejected if a file at that `path_hash` already exists. The client handles `409` by re-fetching state, re-classifying, and surfacing a `Plan` conflict to the user.
+
+### 3.5 `size_bytes` always means plaintext size
+
+This trips up every integrator at least once:
+
+| Where you see it | What it means |
+|---|---|
+| `FileMetadata.size_bytes`, manifest, DB row | **Plaintext** size |
+| HTTP `Content-Length` on download | **Ciphertext** size (storage-backend reported) |
+| HTTP `X-Size-Bytes` header on download | **Plaintext** size (use this for UI) |
+
+Use `salted_hash`, not `size_bytes`, to decide whether two files have the same content.
+
+---
+
+## 4. Quick Starts
+
+Each quick start is a minimum-viable wire-up — enough to confirm the path works. The reference CLI in `hcfs-client-cli/` is the canonical worked example; consult it before building anything elaborate.
+
+### 4.1 Rust / Tauri (recommended for desktop)
+
+Add the dependency from a path or git ref (no crates.io publish yet):
+
+```toml
+[dependencies]
+hcfs-client = { git = "https://github.com/thenervelab/hcfs", package = "hcfs-client" }
+tokio = { version = "1", features = ["full"] }
+```
+
+Wire a `Drive` into a Tauri command. The pattern is: build a `Drive`, attach config, unlock with the user's password, run the sync.
+
+```rust
+use hcfs_client::client::HcfsClientConfig;
+use hcfs_client::drive::Drive;
+use hcfs_client::sync::{SyncConflictResolution, SyncMode};
+use std::path::PathBuf;
+
+#[tauri::command]
+async fn sync_folder(
+    folder: PathBuf,
+    password: String,
+    server_url: String,
+    ss58_address: String,
+    bearer_token: String,
+) -> Result<String, String> {
+    let mut drive = Drive::new(&folder);
+
+    let config = HcfsClientConfig {
+        base_url: server_url,
+        bearer_token,
+        ss58_address,
+        folder_hash: hcfs_client::drive::keys::folder_hash("default"),
+        accept_invalid_certs: false,
+        ..Default::default()
+    };
+    drive.set_config(config).map_err(|e| e.to_string())?;
+    drive.unlock(&password).map_err(|e| e.to_string())?;
+
+    // First-time only: drive.init(&password, None) to generate a mnemonic.
+    // Returns the 24 words — show them to the user once, never persist plaintext.
+
+    let outcome = drive
+        .sync_with_resolver(SyncMode::NonInteractive, |_conflict| {
+            // For a desktop app, queue conflicts to the UI thread instead.
+            SyncConflictResolution::Skip
+        })
+        .await
+        .map_err(|e| e.to_string())?;
+
+    Ok(format!(
+        "uploaded {}, downloaded {}, conflicts {}",
+        outcome.files_uploaded, outcome.files_downloaded, outcome.conflicts_skipped
+    ))
+}
+```
+
+What's missing from this snippet — intentionally, to keep it under 30 lines — is progress callbacks via `Drive::set_progress_handlers`, `CancellationToken` wiring, and the conflict-resolution UX. All three are in `hcfs-client-cli/src/sync.rs`. Read that file before implementing your own.
+
+### 4.2 TypeScript / Electron (WASM crypto + your HTTP)
+
+`@hippius/hcfs-client-wasm` is published as a `wasm-pack --target web` module exposing crypto primitives only. You write the HTTP, sync, and state-persistence layers in TypeScript.
+
+```bash
+npm install @hippius/hcfs-client-wasm
+```
+
+A minimum encrypt-then-upload sketch (exports verified against `hcfs-client-wasm/src/lib.rs`):
+
+```ts
+import init, {
+  derive_signing_key,        // (mnemonic) → SecretBytes (32-byte Ed25519 seed)
+  derive_file_key,           // (master_mnemonic, folder_label) → SecretBytes (32-byte XChaCha20 key)
+  compute_path_hash,         // (relative_path) → Uint8Array (BLAKE3, 32 bytes)
+  compute_salted_hash,       // (ss58_address, plaintext) → Uint8Array (BLAKE3, 32 bytes)
+  encrypt_for_upload,        // (file_key, plaintext) → EncryptedUpload { ciphertext, ciphertext_hash }
+  sign_manifest_text,        // (signing_key, ciphertext_hash) → SignedManifest { signature, verifying_key }
+} from "@hippius/hcfs-client-wasm";
+import { generateMnemonic } from "@scure/bip39";
+import { wordlist } from "@scure/bip39/wordlists/english";
+
+await init(); // load the .wasm
+
+// One-time: generate a 24-word mnemonic in JS, then store it encrypted (Argon2id)
+const mnemonic = generateMnemonic(wordlist, 256);
+
+// Per upload:
+const signingKey = derive_signing_key(mnemonic);              // SecretBytes
+const fileKey    = derive_file_key(mnemonic, "default");      // SecretBytes (folder-scoped)
+const plaintext  = await readFile("notes.md");                // Uint8Array
+
+const encrypted = encrypt_for_upload(fileKey, plaintext);     // produces base_nonce-prefixed blob
+const pathHash   = compute_path_hash("notes.md");
+const saltedHash = compute_salted_hash(ss58Address, plaintext);
+
+const signed = sign_manifest_text(signingKey, encrypted.ciphertext_hash);
+
+const manifest = {
+  ss58_address:     ss58Address,
+  folder_hash:      folderHash,                  // 16-char hex of folder label, see §6.1
+  ciphertext_hash:  encrypted.ciphertext_hash,   // BLAKE3 hex of ciphertext blob
+  size_bytes:       plaintext.byteLength,        // plaintext length
+  timestamp:        Math.floor(Date.now() / 1000),
+  signature:        Array.from(signed.signature),       // [u8; 64]
+  signing_key:      Array.from(signed.verifying_key),   // [u8; 32] — the public key
+  path_hash:        Array.from(pathHash),
+  salted_hash:      Array.from(saltedHash),
+  revision_seq:     1,                           // strictly increasing per file
+  base_revision_id: null,                        // null for new files
+  encrypted_path:   [],                          // see api/register-relative-paths.md
+  file_name:        "notes.md",
+  relative_path:    "notes.md",
+};
+
+const form = new FormData();
+form.append("manifest", JSON.stringify(manifest));
+form.append("ciphertext", new Blob([encrypted.ciphertext]));
+await fetch(`${serverUrl}/upload`, {
+  method: "POST",
+  headers: { Authorization: `Bearer ${ss58Address}` },
+  body: form,
+});
+```
+
+What you still owe yourself: persisting the encrypted mnemonic (the WASM crate exposes `argon2id_derive` and `open_mnemonic_blob` to help), building the three-tree state, paginating `/get_state`, and handling `409` conflicts. Treat this path as "I have a strong reason to avoid Rust"; otherwise prefer 4.1.
+
+> The WASM `SecretBytes` / `SecretString` handles are zeroize-on-drop. Pass them between WASM functions directly rather than calling `.expose()` — once a buffer crosses into a JS `Uint8Array`, it cannot be reliably scrubbed.
+
+### 4.3 Direct HTTP (any language)
+
+Three calls get you a working read-only viewer:
+
+```bash
+# 1. List files in a folder
+curl -H "Authorization: Bearer $SS58" \
+     "$SERVER/get_state/$SS58/$FOLDER_HASH?offset=0&limit=1000"
+
+# 2. Download a file (returns ciphertext + headers)
+curl -H "Authorization: Bearer $SS58" \
+     -o ciphertext.bin -D headers.txt \
+     "$SERVER/download/$SS58/$FOLDER_HASH/$FILE_ID"
+
+# 3. Decrypt locally with the encryption key + nonce from headers/manifest
+#    (See §6 for the exact algorithm.)
+```
+
+Uploading from raw HTTP requires the full crypto stack from §6 — there is no shortcut.
+
+---
+
+## 5. REST API Reference
+
+The full REST API lives in its own subdirectory — each endpoint has its own page with request shape, response shape, status codes, and a working `curl` example.
+
+**Start here:** [`api/overview.md`](./api/overview.md) — base URL, prerequisites, and the grouped endpoint index.
+
+Two pages every endpoint depends on:
+
+- [`api/auth.md`](./api/auth.md) — the bearer-token model
+- [`api/errors.md`](./api/errors.md) — the `NetworkResponse<T>` envelope, the error-code catalog, and the optimistic-concurrency rules that produce `Conflict`
+
+A summary for orientation — follow the links for detail:
+
+| Area | Pages |
+|---|---|
+| File lifecycle (HCFS native, end-to-end encrypted) | [`upload`](./api/upload.md) · [`download`](./api/download.md) · [`delete`](./api/delete.md) |
+| File lifecycle (S3-compatible gateway, server-side) | [`s3-gateway`](./api/s3-gateway.md) |
+| State and discovery | [`get-state`](./api/get-state.md) · [`browse`](./api/browse.md) · [`search-files`](./api/search-files.md) · [`register-relative-paths`](./api/register-relative-paths.md) |
+| Folder lifecycle | [`folders`](./api/folders.md) |
+| Rename | [`rename-files`](./api/rename-files.md) |
+| Chunked / resumable upload | [`upload-session`](./api/upload-session.md) |
+
+---
+
+## 6. Cryptographic Spec
+
+This section is for raw-HTTP integrators. If you are using `hcfs-client` or `hcfs-client-wasm`, the library does this for you — but read it anyway, because nothing about HCFS makes sense if you don't know what is encrypted, with what key, under what nonce.
+
+### 6.1 Key derivation
+
+```
+master_mnemonic    : 24 BIP-39 words, generated client-side
+folder_label       : utf-8 string, user-chosen (e.g., "default", "photos")
+
+folder_entropy     = SHA-256( master_seed[..32] || folder_label )
+folder_mnemonic    = BIP-39::from_entropy( folder_entropy )       // 24 words
+folder_seed        = folder_mnemonic.to_seed("")                  // 64 bytes, empty passphrase
+signing_key        = Ed25519::from_bytes( folder_seed[..32] )     // ed25519-dalek
+encryption_key     = folder_seed[..32]                            // XChaCha20-Poly1305 key
+ss58_address       = SS58( signing_key.public, prefix=42 )        // bittensor-substrate prefix
+folder_hash        = hex( SHA-256(folder_label) )[..16]
+```
+
+Two notes that look wrong but are intentional:
+
+- **Empty BIP-39 passphrase.** This is how the client guarantees that the same mnemonic recovers the same `ss58_address` on every device. Adding a passphrase would silently fork identities.
+- **Same 32 bytes used for both signing and encryption.** Ed25519 only consumes the seed, never the public key, and XChaCha20-Poly1305 is a separate primitive. There is no known attack from key reuse across these two algorithms with this specific construction. Do not generalize this pattern.
+
+### 6.2 Mnemonic-at-rest encryption
+
+The desktop client stores `enc_mnemonic.json` in `.hippius/`:
+
+```
+salt           : 16 random bytes
+key            = PBKDF2-HMAC-SHA256( password, salt, 600_000 iterations, 32 bytes out )
+iv             : 12 random bytes
+ciphertext+tag = AES-256-GCM::seal( key, iv, mnemonic_bytes, aad=empty )
+file mode      : 0o600 on Unix
+```
+
+The legacy iteration count is 10_000 (`PBKDF2_LEGACY_ITERATIONS`); current is 600_000. New writes always use 600_000 and persist the count.
+
+The WASM crate uses **Argon2id** with OWASP 2023 second-profile minimums (`MIN_ARGON2_MEMORY_KIB = 19456`, `MIN_ARGON2_TIME_COST = 2`, `MIN_ARGON2_PARALLELISM = 1`) for browser contexts where Argon2 is the modern default. The two storage formats are not interchangeable.
+
+### 6.3 File encryption — wire format
+
+The on-the-wire ciphertext is a chunked, framed format. Both `hcfs-client` and `hcfs-client-wasm` produce byte-identical blobs for the same key, plaintext, and `base_nonce`.
+
+```
+chunk_size      : 256 KiB plaintext (ENCRYPTION_CHUNK_SIZE in hcfs-client/src/crypto.rs)
+base_nonce      : 24 random bytes (XChaCha20 nonce length, generated once per file)
+
+[base_nonce: 24 bytes]
+[chunk_count: u32 little-endian]
+for each chunk i in 0..chunk_count:
+    [chunk_len: u32 LE]   = ciphertext_bytes_len + 16 (Poly1305 auth tag)
+    [ciphertext_bytes]
+    [auth_tag: 16 bytes]
+```
+
+A per-chunk nonce is derived from the base nonce and the chunk index, so each chunk is encrypted under a unique nonce even though only one is stored on the wire:
+
+```
+chunk_nonce[..8]  = base_nonce[..8] XOR chunk_index.to_le_bytes()  (u64 little-endian)
+chunk_nonce[8..]  = base_nonce[8..]
+ciphertext_chunk  = XChaCha20-Poly1305::encrypt(key=file_key,
+                                                nonce=chunk_nonce,
+                                                aad=empty,
+                                                plaintext=chunk_i)
+```
+
+A zero-byte file is encoded with `chunk_count=1` and a single empty-plaintext frame (still a 16-byte tag). The `ciphertext_hash` field of the manifest is `BLAKE3(entire blob).hex()`.
+
+### 6.4 Hashes
+
+```
+path_hash      = BLAKE3( relative_path.utf8_bytes ) → 32 bytes
+                 (hex form is the file_id used in URLs)
+
+salted_hash    = BLAKE3( user_id.utf8_bytes || plaintext_bytes ) → 32 bytes
+                 (used for content-equality checks during sync;
+                  cheap to recompute, doesn't depend on the random nonce)
+```
+
+`user_id` here is the SS58 address.
+
+### 6.5 Manifest schema and signing
+
+Authoritative source: `hcfs-shared/src/network.rs::Manifest`.
+
+```
+ss58_address       : String                  (alias: "user_id" — server accepts either)
+folder_hash        : String                  (16-char hex of folder label)
+ciphertext_hash    : String                  (BLAKE3 hex of the ciphertext blob)
+size_bytes         : u64                     (plaintext size)
+timestamp          : i64                     (unix seconds, client-supplied)
+signature          : [u8; 64]                (Ed25519 signature — see below)
+signing_key        : [u8; 32]                (Ed25519 public verifying key)
+path_hash          : [u8; 32]                (BLAKE3 of relative path)
+salted_hash        : [u8; 32]                (BLAKE3(ss58_address || plaintext))
+revision_seq       : u64                     (strictly > current; new files: 1)
+base_revision_id   : Option<[u8; 32]>        (null for new files; required for OCC updates)
+encrypted_path     : Vec<u8>                 (sealed relative path, see encrypt_relative_path)
+file_name          : Option<String>          (plaintext filename, for download progress UI)
+relative_path      : Option<String>          (plaintext relative path, for new-style routing)
+```
+
+`revision_id` is **not** a manifest field — the server assigns it on accept and returns it in `UploadResult`.
+
+#### Signature scheme
+
+The signature is **not** over the canonical JSON of the manifest. It is over a fixed-format Terms-of-Service declaration containing the ciphertext hash:
+
+```
+text = "I here by declare that the file with hash {ciphertext_hash} that i am uploading is in par with the ToS of the provider"
+signature = Ed25519::sign(signing_key, text.as_bytes())
+```
+
+This is implemented as `Manifest::generate_text(ciphertext_hash)` in `hcfs-shared` and mirrored byte-for-byte by `manifest_tos_text` in `hcfs-client-wasm`. A cross-crate test pins the format — any drift breaks uploads server-wide. The string is intentionally not a configurable template.
+
+The implication for integrators: signing only commits to the **ciphertext hash**. The other manifest fields (path hash, sizes, revision metadata) are bound by the server's revision check + `salted_hash` comparison during sync, not by the signature.
+
+### 6.6 Multipart upload format
+
+```
+POST /upload
+Content-Type: multipart/form-data; boundary=...
+
+--boundary
+Content-Disposition: form-data; name="manifest"
+Content-Type: application/json
+
+{ ...manifest JSON, signature included... }
+--boundary
+Content-Disposition: form-data; name="ciphertext"
+Content-Type: application/octet-stream
+
+<ciphertext_blob bytes>
+--boundary--
+```
+
+Field order matters: the server peeks the **first** multipart field's name to route the request. For the HCFS native path it must be `manifest`; the S3-compatible gateway path expects `account_ss58` instead — see [`api/s3-gateway.md`](./api/s3-gateway.md).
+
+---
+
+## 7. Sync Protocol
+
+The sync engine lives in `hcfs-client/src/sync/` and `hcfs-client/src/drive/sync_flow.rs`. The classification matrix is in §3.3; this section covers the execution loop and the failure modes a third-party client must handle.
+
+### 7.1 The loop, end to end
+
+```
+1. scan_local_files()        → local: FileTree   (BLAKE3 path_hash + content)
+2. fetch_remote_state()      → remote: FileTree  (paginated /get_state)
+3. load synced from disk     → synced: FileTree  (.hippius/sync_state.json)
+4. SyncPlan::build(local, remote, synced)
+       → uploads, downloads, local_deletes, remote_deletes, conflicts
+5. extract_renames()         → promote upload+delete pairs to RenameOps
+       Tier 1: watcher-supplied hints (best, fast)
+       Tier 2: content-hash pairing (fallback)
+6. resolve conflicts via your callback (KeepLocal / AcceptRemote / KeepBoth / Skip)
+7. execute concurrently:
+       uploads + downloads (bounded, cancellable)
+   then renames (POST /rename_files, batch)
+   then serial local deletes, then remote deletes
+8. fold successes into a new synced tree, atomic-write to disk
+9. return SyncOutcome
+```
+
+If you re-implement this in another language, **persist the synced tree atomically** — write to a temp file, fsync, rename. Losing it forces a full re-upload because every local file looks like a `LocalCreate`. The Rust client also keeps a `.bak` of the previous synced tree.
+
+### 7.2 Conflicts
+
+Four types, surfaced via the resolver callback you pass to `Drive::sync_with_resolver`:
+
+| Type | What happened |
+|---|---|
+| `ModifyModify` | Both sides changed the file to different contents |
+| `ModifyDelete` | You modified locally, another device deleted |
+| `DeleteModify` | You deleted locally, another device modified |
+| `CreateCreate` | Same `path_hash`, two different first-time creations |
+
+Four resolutions, all defined in `hcfs-client/src/sync/conflict.rs`:
+
+| Resolution | Semantics |
+|---|---|
+| `KeepLocal` | Upload local, overwrite remote |
+| `AcceptRemote` | Download remote, overwrite local |
+| `KeepBoth` | Rename local to `…<basename>.conflict<ext>`, then download remote |
+| `Skip` | Leave both sides untouched this run; surface again next sync |
+
+For a desktop app, queue conflicts to the UI thread rather than answering them inside the resolver closure — the resolver runs on the sync task and blocking it stalls the whole run.
+
+### 7.3 Server-side optimistic concurrency (what you'll see)
+
+Two failure modes are normal, not bugs:
+
+- **`409 conflict` on upload** — `base_revision_id` did not match the server's current revision. The server includes the current `revision_id` in the response. Re-fetch state, re-classify, surface as a `ModifyModify` conflict if the local content also changed.
+- **`400 stale_sequence`** — your `revision_seq` is ≤ the current. Bump `revision_seq` to `current_seq + 1` and retry.
+
+### 7.4 Retries and resumable uploads
+
+Small files: just retry the multipart upload. Large files: open an `/upload/session`, push chunks in parallel up to 16 MiB each, finalize. Sessions survive process restarts and can be resumed via `/upload/session/{id}/status`.
+
+The Rust client switches to chunked sessions automatically above an internal threshold (`hcfs-client/src/client/chunked.rs`); a third-party client should mirror that policy or accept slow re-uploads on flaky networks.
+
+---
+
+## 8. Production Notes
+
+What bites people in week three.
+
+### 8.1 Where to put the encrypted mnemonic
+
+| Platform | Recommended store |
+|---|---|
+| Tauri / native macOS | macOS Keychain (`security` / `tauri-plugin-keyring`) |
+| Tauri / native Windows | DPAPI via `tauri-plugin-keyring` or Windows Credential Manager |
+| Tauri / native Linux | Secret Service (libsecret); fall back to `enc_mnemonic.json` (0o600) for headless servers |
+| Electron | `safeStorage` (uses Keychain / DPAPI under the hood) |
+| Browser-only | Argon2id-protected blob in IndexedDB, unlocked in-memory for the session only |
+
+The Rust client's default — `enc_mnemonic.json` with mode `0o600` in the config directory — is acceptable on a single-user developer machine and not acceptable on a shared one.
+
+### 8.2 Background sync
+
+- Use `CancellationToken` (re-exported from `hcfs-client::CancellationToken`) on every sync run. Tie it to the user's "pause sync" toggle, app-quit, and laptop-sleep events.
+- Don't spawn one sync task per file change — debounce. The CLI runs full passes; the desktop reference app uses a watcher to feed Tier-1 rename hints into the next pass.
+- Store every spawned `JoinHandle` and await on shutdown; dropped handles silently swallow panics.
+
+### 8.3 Conflict UX
+
+- Show the user *what changed* (size, modified time, filename), not the conflict-type enum name.
+- Default the action to `KeepBoth` for `ModifyModify` and `CreateCreate` — it never destroys data.
+- For `ModifyDelete` / `DeleteModify`, default to `KeepLocal` / `AcceptRemote` respectively (favor whichever side made the most recent edit).
+- Persist unresolved conflicts so the user can come back to them; `Skip` is a feature, not an error.
+
+### 8.4 What the server will not do for you
+
+- **No client-side flow control.** Your client is responsible for bounding its own concurrency so it doesn't starve itself or flood a slow network. The Rust client uses an internal cap; if you roll your own, pick 8–16 concurrent uploads and tune from there.
+- **No background re-encryption.** Rotating an encryption key means decrypting every file with the old key and re-uploading it under the new one. Plan this UX explicitly.
+- **No password reset.** Lose the mnemonic, lose the data. Build mnemonic backup into onboarding, not into "advanced settings."
+
+### 8.5 Common pitfalls
+
+| Pitfall | Cause | Fix |
+|---|---|---|
+| Every sync re-uploads all files | Lost / corrupt `sync_state.json` | Atomic write + `.bak`; never edit by hand |
+| `409` storms after a clock change | Multiple devices racing; one wins, others retry | Add jitter; trust the conflict resolver |
+| Plaintext path leaks to logs | Logging the relative path before hashing | Log `path_hash` only; never `relative_path` |
+| Browse / search show empty names | Forgot `POST /register_relative_paths` after upload | Register encrypted relative paths in the same pass as upload |
+| `Content-Length` ≠ file size in UI | Showing ciphertext bytes | Use `X-Size-Bytes` for UI, `Content-Length` only for HTTP progress |
+| `Drive::unlock` fails after password change | Old `enc_mnemonic.json` used legacy iterations | Re-encrypt on first successful unlock |

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -140,6 +140,38 @@ const sidebars: SidebarsConfig = {
       ],
     },
 
+    // ── HCFS ───────────────────────────────────────────────────────
+    {
+      type: "category",
+      label: "HCFS",
+      collapsed: true,
+      items: [
+        "hcfs/integration-guide",
+        "hcfs/architecture-diagrams",
+        {
+          type: "category",
+          label: "REST API",
+          collapsed: true,
+          items: [
+            "hcfs/api/overview",
+            "hcfs/api/auth",
+            "hcfs/api/errors",
+            "hcfs/api/upload",
+            "hcfs/api/download",
+            "hcfs/api/delete",
+            "hcfs/api/s3-gateway",
+            "hcfs/api/get-state",
+            "hcfs/api/browse",
+            "hcfs/api/search-files",
+            "hcfs/api/register-relative-paths",
+            "hcfs/api/folders",
+            "hcfs/api/rename-files",
+            "hcfs/api/upload-session",
+          ],
+        },
+      ],
+    },
+
     // ── SUPPORT ────────────────────────────────────────────────────
     "use/help-support",
   ],

--- a/static/img/hcfs/diagrams/01-overall-architecture.svg
+++ b/static/img/hcfs/diagrams/01-overall-architecture.svg
@@ -1,0 +1,174 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1400 1000" width="1400" height="1000" role="img" aria-label="HCFS overall architecture">
+  <defs>
+    <style><![CDATA[
+      .bg { fill: #fafafa; }
+      .title { font: 700 28px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #111827; }
+      .subtitle { font: 400 14px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #4b5563; }
+      .section-tag { font: 700 11px -apple-system, sans-serif; letter-spacing: 0.12em; fill: #6b7280; }
+      .group-title { font: 700 16px -apple-system, sans-serif; fill: #111827; }
+      .box-title { font: 700 14px -apple-system, sans-serif; fill: #111827; }
+      .box-sub { font: 400 11px -apple-system, sans-serif; fill: #6b7280; }
+      .item { font: 400 12px -apple-system, sans-serif; fill: #1f2937; }
+      .code { font: 400 11px ui-monospace, SFMono-Regular, Menlo, monospace; fill: #374151; }
+      .edge { font: 600 11px -apple-system, sans-serif; fill: #1f2937; }
+      .edge-sub { font: 400 10px -apple-system, sans-serif; fill: #6b7280; }
+      .divider { stroke: #e5e7eb; stroke-width: 1; stroke-dasharray: 4 4; }
+      .arrow { stroke: #374151; stroke-width: 1.8; fill: none; }
+      .arrow-async { stroke: #7c3aed; stroke-width: 1.6; fill: none; stroke-dasharray: 5 4; }
+    ]]></style>
+    <marker id="ah" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#374151"/>
+    </marker>
+    <marker id="ah-async" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#7c3aed"/>
+    </marker>
+    <filter id="soft" x="-5%" y="-5%" width="110%" height="110%">
+      <feDropShadow dx="0" dy="1" stdDeviation="1.5" flood-color="#0f172a" flood-opacity="0.08"/>
+    </filter>
+  </defs>
+
+  <rect class="bg" width="1400" height="1000"/>
+
+  <!-- Title -->
+  <text x="60" y="52" class="title">HCFS · Overall architecture</text>
+  <text x="60" y="78" class="subtitle">Two client protocols (native HCFS + S3-compatible) share a single axum server that persists ciphertext to the Arion storage gateway. The server never sees plaintext on the HCFS path.</text>
+
+  <!-- ═══════════════ Clients ═══════════════ -->
+  <text x="60" y="122" class="section-tag">CLIENTS</text>
+
+  <!-- HCFS client card -->
+  <g filter="url(#soft)">
+    <rect x="60" y="140" width="560" height="180" rx="10" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  </g>
+  <text x="82" y="168" class="box-title">HCFS native clients</text>
+  <text x="82" y="186" class="box-sub">hcfs-client-cli · hippius-desktop (Tauri) · hcfs-client-wasm</text>
+  <line x1="82" y1="198" x2="598" y2="198" class="divider"/>
+  <text x="82" y="220" class="item">• BIP-39 mnemonic → Ed25519 signing + XChaCha20 encryption key</text>
+  <text x="82" y="240" class="item">• Streams ciphertext only · path_hash = BLAKE3(relative path)</text>
+  <text x="82" y="260" class="item">• Three-tree sync engine (local · remote · synced)</text>
+  <text x="82" y="280" class="item">• Optimistic concurrency via base_revision_id</text>
+  <text x="82" y="304" class="code">upload body → multipart: "manifest" (JSON) + "ciphertext" (stream)</text>
+
+  <!-- S3 gateway clients card -->
+  <g filter="url(#soft)">
+    <rect x="780" y="140" width="560" height="180" rx="10" fill="#ecfeff" stroke="#0891b2" stroke-width="1.5"/>
+  </g>
+  <text x="802" y="168" class="box-title">S3-compatible gateway clients</text>
+  <text x="802" y="186" class="box-sub">any S3 SDK · hippius-s3 gateway · HCP tools · third-party apps</text>
+  <line x1="802" y1="198" x2="1318" y2="198" class="divider"/>
+  <text x="802" y="220" class="item">• Authenticated by SS58 address (bearer token)</text>
+  <text x="802" y="240" class="item">• Raw file bytes · server derives path/hash metadata</text>
+  <text x="802" y="260" class="item">• No per-file client encryption · no manifest</text>
+  <text x="802" y="280" class="item">• Simpler endpoints: no folder_hash in URL</text>
+  <text x="802" y="304" class="code">upload body → multipart: "account_ss58" (text) + "file" (stream)</text>
+
+  <!-- Wire labels -->
+  <text x="340" y="352" text-anchor="middle" class="edge">Manifest + Ciphertext</text>
+  <text x="340" y="366" text-anchor="middle" class="edge-sub">HTTPS · bearer token · signed manifest</text>
+  <path d="M340 370 L340 410" class="arrow" marker-end="url(#ah)"/>
+
+  <text x="1060" y="352" text-anchor="middle" class="edge">account_ss58 + file bytes</text>
+  <text x="1060" y="366" text-anchor="middle" class="edge-sub">HTTPS · bearer token</text>
+  <path d="M1060 370 L1060 410" class="arrow" marker-end="url(#ah)"/>
+
+  <!-- ═══════════════ Server ═══════════════ -->
+  <text x="60" y="436" class="section-tag">SERVER · hcfs-server (axum, 0.0.0.0:9999)</text>
+
+  <g filter="url(#soft)">
+    <rect x="60" y="450" width="1280" height="300" rx="12" fill="#fff7ed" stroke="#d97706" stroke-width="1.5"/>
+  </g>
+
+  <!-- Upload dispatcher band -->
+  <rect x="80" y="470" width="1240" height="70" rx="8" fill="#ffedd5" stroke="#d97706" stroke-width="1"/>
+  <text x="100" y="494" class="box-title">POST /upload — dispatcher</text>
+  <text x="100" y="512" class="code">peek first multipart field · "manifest" → handle_hcfs_upload · "account_ss58" → handle_s3_upload</text>
+  <text x="100" y="528" class="box-sub">handlers/upload.rs:29</text>
+
+  <!-- Two handler branches -->
+  <g>
+    <rect x="80" y="560" width="600" height="110" rx="8" fill="#fffbeb" stroke="#ca8a04" stroke-width="1"/>
+    <text x="100" y="584" class="box-title">handle_hcfs_upload</text>
+    <text x="100" y="602" class="item">• validate signature over manifest · check_upload_conflicts</text>
+    <text x="100" y="620" class="item">• upsert_file_checked (base_revision_id CAS)</text>
+    <text x="100" y="638" class="item">• download URL: /download/{ss58}/{folder_hash}/{file_id}</text>
+    <text x="100" y="656" class="code">encrypted_path · path_hash · salted_hash from client</text>
+  </g>
+  <g>
+    <rect x="700" y="560" width="620" height="110" rx="8" fill="#fffbeb" stroke="#ca8a04" stroke-width="1"/>
+    <text x="720" y="584" class="box-title">handle_s3_upload</text>
+    <text x="720" y="602" class="item">• authorize_s3_upload (SS58 matches token owner)</text>
+    <text x="720" y="620" class="item">• build_s3_file_record (filename → path_hash) · persist_s3_record</text>
+    <text x="720" y="638" class="item">• download URL: /download/{ss58}/{file_id} (no folder_hash)</text>
+    <text x="720" y="656" class="code">server computes hashes · no encryption layer</text>
+  </g>
+
+  <!-- Middleware strip -->
+  <rect x="80" y="690" width="1240" height="44" rx="8" fill="#ffffff" stroke="#fde68a" stroke-width="1"/>
+  <text x="100" y="714" class="item">shared layer → <tspan class="code">auth::validate_bearer_token</tspan> middleware · inline <tspan class="code">path_validator</tspan> · AppState (DB pool, HTTP pool, Arion round-robin, billing JoinSet) · metrics</text>
+
+  <!-- Arrows from handlers to storage backends -->
+  <path d="M380 670 L380 790" class="arrow" marker-end="url(#ah)"/>
+  <text x="392" y="735" class="edge-sub">StorageBackend.upload</text>
+
+  <path d="M1010 670 L1010 790" class="arrow" marker-end="url(#ah)"/>
+  <text x="1022" y="735" class="edge-sub">StorageBackend.upload</text>
+
+  <!-- Dispatcher fan-out arrows -->
+  <path d="M380 540 L380 560" class="arrow" marker-end="url(#ah)"/>
+  <path d="M1010 540 L1010 560" class="arrow" marker-end="url(#ah)"/>
+
+  <!-- ═══════════════ Backends ═══════════════ -->
+  <text x="60" y="790" class="section-tag">STORAGE PLANE</text>
+
+  <!-- PostgreSQL -->
+  <g filter="url(#soft)">
+    <rect x="60" y="810" width="360" height="150" rx="10" fill="#f3f4f6" stroke="#6b7280" stroke-width="1.5"/>
+  </g>
+  <text x="82" y="838" class="box-title">PostgreSQL · metadata</text>
+  <text x="82" y="856" class="box-sub">database.rs (sqlx)</text>
+  <text x="82" y="882" class="item">file_records · folder_registry</text>
+  <text x="82" y="902" class="item">upload_sessions · user_storage_summary</text>
+  <text x="82" y="922" class="item">path_registry</text>
+  <text x="82" y="948" class="code">path_hash · arion_hash · revision_id</text>
+
+  <!-- Arion -->
+  <g filter="url(#soft)">
+    <rect x="460" y="810" width="880" height="150" rx="10" fill="#f5f3ff" stroke="#7c3aed" stroke-width="1.5"/>
+  </g>
+  <text x="482" y="838" class="box-title">Arion gateway pool · ciphertext store</text>
+  <text x="482" y="856" class="box-sub">IPFS-backed · round-robin across configured endpoints</text>
+  <text x="482" y="884" class="item">• <tspan class="code">next_arion_url</tspan> for each request · streamed upload from multipart field</text>
+  <text x="482" y="904" class="item">• content addressed by BLAKE3 of ciphertext (<tspan class="code">arion_hash</tspan>)</text>
+  <text x="482" y="924" class="item">• HTTP Range GET for partial downloads</text>
+
+  <!-- Arrows server → backends -->
+  <path d="M240 750 L240 810" class="arrow" marker-end="url(#ah)"/>
+  <text x="252" y="785" class="edge-sub">upsert_file_checked</text>
+
+  <path d="M900 750 L900 810" class="arrow" marker-end="url(#ah)"/>
+  <text x="912" y="785" class="edge-sub">StorageBackend.upload · PUT ciphertext</text>
+
+  <!-- Billing sidecar box -->
+  <g filter="url(#soft)">
+    <rect x="1180" y="430" width="160" height="70" rx="8" fill="#fdf4ff" stroke="#a21caf" stroke-width="1"/>
+  </g>
+  <text x="1200" y="454" class="box-title">Hippius billing</text>
+  <text x="1200" y="472" class="item">async JoinSet</text>
+  <text x="1200" y="488" class="item">fire-and-forget</text>
+
+  <path d="M1180 465 L1090 465" class="arrow-async" marker-end="url(#ah-async)"/>
+
+  <!-- Legend -->
+  <g transform="translate(60, 985)">
+    <rect x="0" y="-15" width="14" height="14" fill="#eff6ff" stroke="#3b82f6"/>
+    <text x="20" y="-3" class="item">Trust boundary (plaintext)</text>
+    <rect x="220" y="-15" width="14" height="14" fill="#ecfeff" stroke="#0891b2"/>
+    <text x="240" y="-3" class="item">S3 ingress</text>
+    <rect x="360" y="-15" width="14" height="14" fill="#fff7ed" stroke="#d97706"/>
+    <text x="380" y="-3" class="item">Server</text>
+    <rect x="460" y="-15" width="14" height="14" fill="#f5f3ff" stroke="#7c3aed"/>
+    <text x="480" y="-3" class="item">Arion storage</text>
+    <line x1="620" y1="-8" x2="660" y2="-8" class="arrow-async"/>
+    <text x="668" y="-3" class="item">async / fire-and-forget</text>
+  </g>
+</svg>

--- a/static/img/hcfs/diagrams/02-server-ingestion.svg
+++ b/static/img/hcfs/diagrams/02-server-ingestion.svg
@@ -1,0 +1,192 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1500 1100" width="1500" height="1100" role="img" aria-label="Server ingestion: HCFS vs S3 clients">
+  <defs>
+    <style><![CDATA[
+      .bg { fill: #fafafa; }
+      .title { font: 700 28px -apple-system, "Segoe UI", sans-serif; fill: #111827; }
+      .subtitle { font: 400 14px -apple-system, sans-serif; fill: #4b5563; }
+      .section-tag { font: 700 11px -apple-system, sans-serif; letter-spacing: 0.12em; fill: #6b7280; }
+      .box-title { font: 700 14px -apple-system, sans-serif; fill: #111827; }
+      .box-sub { font: 400 11px -apple-system, sans-serif; fill: #6b7280; }
+      .item { font: 400 12px -apple-system, sans-serif; fill: #1f2937; }
+      .item-sm { font: 400 11px -apple-system, sans-serif; fill: #374151; }
+      .code { font: 400 11px ui-monospace, SFMono-Regular, Menlo, monospace; fill: #374151; }
+      .code-b { font: 600 11px ui-monospace, SFMono-Regular, Menlo, monospace; fill: #111827; }
+      .step-num { font: 700 14px -apple-system, sans-serif; fill: #ffffff; }
+      .edge { font: 600 11px -apple-system, sans-serif; fill: #1f2937; }
+      .edge-sub { font: 400 10px -apple-system, sans-serif; fill: #6b7280; }
+      .arrow { stroke: #374151; stroke-width: 1.8; fill: none; }
+      .arrow-async { stroke: #7c3aed; stroke-width: 1.6; fill: none; stroke-dasharray: 5 4; }
+      .divider { stroke: #e5e7eb; stroke-width: 1; stroke-dasharray: 4 4; }
+      .lane-hcfs { fill: #eff6ff; }
+      .lane-s3 { fill: #ecfeff; }
+      .lane-shared { fill: #fff7ed; }
+    ]]></style>
+    <marker id="ah" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#374151"/>
+    </marker>
+    <marker id="ah-async" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#7c3aed"/>
+    </marker>
+    <filter id="soft" x="-5%" y="-5%" width="110%" height="110%">
+      <feDropShadow dx="0" dy="1" stdDeviation="1.5" flood-color="#0f172a" flood-opacity="0.08"/>
+    </filter>
+  </defs>
+
+  <rect class="bg" width="1500" height="1100"/>
+
+  <!-- Title -->
+  <text x="60" y="52" class="title">Server ingestion · HCFS native vs S3-compatible</text>
+  <text x="60" y="78" class="subtitle">A single <tspan class="code-b">POST /upload</tspan> endpoint peeks the first multipart field and forks into two handlers. Both write through the same StorageBackend and database.</text>
+
+  <!-- Lane backgrounds -->
+  <rect x="40" y="110" width="680" height="720" rx="10" fill="#f8fafc" stroke="#cbd5e1" stroke-width="1" stroke-dasharray="3 3"/>
+  <rect x="780" y="110" width="680" height="720" rx="10" fill="#f8fafc" stroke="#cbd5e1" stroke-width="1" stroke-dasharray="3 3"/>
+
+  <!-- Lane headers -->
+  <rect x="40" y="110" width="680" height="54" rx="10" class="lane-hcfs" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="64" y="142" class="box-title">HCFS native client path</text>
+  <text x="64" y="158" class="box-sub">client: hcfs-client (CLI, Desktop, WASM) — full E2E encryption</text>
+
+  <rect x="780" y="110" width="680" height="54" rx="10" class="lane-s3" stroke="#0891b2" stroke-width="1.5"/>
+  <text x="804" y="142" class="box-title">S3-compatible gateway path</text>
+  <text x="804" y="158" class="box-sub">client: any S3 SDK or the Hippius S3 gateway — server-side metadata</text>
+
+  <!-- ═════ Step 1: Client composes request ═════ -->
+  <circle cx="62" cy="202" r="14" fill="#3b82f6"/>
+  <text x="62" y="207" text-anchor="middle" class="step-num">1</text>
+  <text x="88" y="207" class="box-title">Client composes request</text>
+  <g filter="url(#soft)">
+    <rect x="60" y="222" width="640" height="120" rx="8" fill="#ffffff" stroke="#3b82f6" stroke-width="1"/>
+  </g>
+  <text x="80" y="246" class="item">• Derives signing_key + encryption_key from BIP-39 mnemonic</text>
+  <text x="80" y="266" class="item">• Encrypts file with XChaCha20-Poly1305 (streamed, 256 KB chunks)</text>
+  <text x="80" y="286" class="item">• Builds + signs <tspan class="code-b">Manifest</tspan> (path_hash, salted_hash, revision_seq, base_revision_id…)</text>
+  <text x="80" y="312" class="code">POST /upload  Content-Type: multipart/form-data</text>
+  <text x="80" y="328" class="code">fields: "manifest" (JSON) → "ciphertext" (binary stream)</text>
+
+  <circle cx="802" cy="202" r="14" fill="#0891b2"/>
+  <text x="802" y="207" text-anchor="middle" class="step-num">1</text>
+  <text x="828" y="207" class="box-title">Client composes request</text>
+  <g filter="url(#soft)">
+    <rect x="800" y="222" width="640" height="120" rx="8" fill="#ffffff" stroke="#0891b2" stroke-width="1"/>
+  </g>
+  <text x="820" y="246" class="item">• Standard S3 PutObject-style request (bucket = ss58 address)</text>
+  <text x="820" y="266" class="item">• No client-side encryption, no manifest, no signatures</text>
+  <text x="820" y="286" class="item">• File name is transmitted in cleartext as part of the form</text>
+  <text x="820" y="312" class="code">POST /upload  Content-Type: multipart/form-data</text>
+  <text x="820" y="328" class="code">fields: "account_ss58" (text) → "file" (binary stream)</text>
+
+  <!-- Down arrows to step 2 -->
+  <path d="M380 342 L380 380" class="arrow" marker-end="url(#ah)"/>
+  <path d="M1120 342 L1120 380" class="arrow" marker-end="url(#ah)"/>
+
+  <!-- ═════ Shared dispatcher band ═════ -->
+  <g filter="url(#soft)">
+    <rect x="40" y="380" width="1420" height="70" rx="10" class="lane-shared" stroke="#d97706" stroke-width="1.5"/>
+  </g>
+  <text x="60" y="406" class="box-title">POST /upload · handlers/upload.rs :: upload()</text>
+  <text x="60" y="424" class="item">validate bearer token → parse multipart → <tspan class="code-b">extract_first_field</tspan> → match on field name:</text>
+  <text x="60" y="440" class="code">"manifest" → handle_hcfs_upload    ·    "account_ss58" → handle_s3_upload    ·    * → 400 Invalid upload request</text>
+
+  <!-- Fork arrows to step 2 boxes -->
+  <path d="M380 450 L380 490" class="arrow" marker-end="url(#ah)"/>
+  <path d="M1120 450 L1120 490" class="arrow" marker-end="url(#ah)"/>
+
+  <!-- ═════ Step 2: Handler authorization + validation ═════ -->
+  <circle cx="62" cy="512" r="14" fill="#3b82f6"/>
+  <text x="62" y="517" text-anchor="middle" class="step-num">2</text>
+  <text x="88" y="517" class="box-title">handle_hcfs_upload</text>
+  <text x="88" y="532" class="box-sub">upload.rs:104 — manifest-driven path</text>
+  <g filter="url(#soft)">
+    <rect x="60" y="542" width="640" height="150" rx="8" fill="#ffffff" stroke="#3b82f6" stroke-width="1"/>
+  </g>
+  <text x="80" y="566" class="item">• <tspan class="code-b">parse_manifest</tspan> → verify Ed25519 signature</text>
+  <text x="80" y="586" class="item">• <tspan class="code-b">authorize_hcfs_upload</tspan>: token ss58 == manifest.ss58 (or admin)</text>
+  <text x="80" y="606" class="item">• <tspan class="code-b">validate_manifest</tspan>: revision_seq monotonic · billing gate</text>
+  <text x="80" y="626" class="item">• <tspan class="code-b">check_upload_conflicts</tspan>: existing row &amp; base_revision_id CAS</text>
+  <text x="80" y="646" class="item">• stream "ciphertext" field via <tspan class="code-b">StorageBackend::upload</tspan></text>
+  <text x="80" y="672" class="code">server never learns: plaintext path · plaintext content · user keys</text>
+
+  <circle cx="802" cy="512" r="14" fill="#0891b2"/>
+  <text x="802" y="517" text-anchor="middle" class="step-num">2</text>
+  <text x="828" y="517" class="box-title">handle_s3_upload</text>
+  <text x="828" y="532" class="box-sub">upload.rs:263 — ss58-driven path</text>
+  <g filter="url(#soft)">
+    <rect x="800" y="542" width="640" height="150" rx="8" fill="#ffffff" stroke="#0891b2" stroke-width="1"/>
+  </g>
+  <text x="820" y="566" class="item">• <tspan class="code-b">authorize_s3_upload</tspan>: token ss58 == account_ss58 (or admin)</text>
+  <text x="820" y="586" class="item">• <tspan class="code-b">extract_file_field</tspan> with cleartext filename</text>
+  <text x="820" y="606" class="item">• stream "file" field via <tspan class="code-b">StorageBackend::upload</tspan></text>
+  <text x="820" y="626" class="item">• <tspan class="code-b">build_s3_file_record</tspan>: filename → path_hash, returns existing size for billing</text>
+  <text x="820" y="646" class="item">• <tspan class="code-b">persist_s3_record</tspan>: upsert + storage cleanup on failure</text>
+  <text x="820" y="672" class="code">server sees cleartext filename — path_hash computed server-side</text>
+
+  <!-- Down arrows to step 3 -->
+  <path d="M380 692 L380 730" class="arrow" marker-end="url(#ah)"/>
+  <path d="M1120 692 L1120 730" class="arrow" marker-end="url(#ah)"/>
+
+  <!-- ═════ Step 3: Record + response shape ═════ -->
+  <circle cx="62" cy="752" r="14" fill="#3b82f6"/>
+  <text x="62" y="757" text-anchor="middle" class="step-num">3</text>
+  <text x="88" y="757" class="box-title">FileRecord fields written</text>
+  <g filter="url(#soft)">
+    <rect x="60" y="772" width="640" height="58" rx="8" fill="#eff6ff" stroke="#3b82f6" stroke-width="1"/>
+  </g>
+  <text x="80" y="794" class="code-b">path_hash · salted_hash · encrypted_path · revision_id · revision_seq</text>
+  <text x="80" y="812" class="code">size_bytes = plaintext size (from manifest)</text>
+
+  <circle cx="802" cy="752" r="14" fill="#0891b2"/>
+  <text x="802" y="757" text-anchor="middle" class="step-num">3</text>
+  <text x="828" y="757" class="box-title">FileRecord fields written</text>
+  <g filter="url(#soft)">
+    <rect x="800" y="772" width="640" height="58" rx="8" fill="#ecfeff" stroke="#0891b2" stroke-width="1"/>
+  </g>
+  <text x="820" y="794" class="code-b">path_hash(filename) · file_name · revision_id · revision_seq</text>
+  <text x="820" y="812" class="code">size_bytes = Content-Length · encrypted_path = null</text>
+
+  <!-- Arrows into convergence -->
+  <path d="M380 830 L380 870 Q380 900 550 900 L720 900" class="arrow" marker-end="url(#ah)"/>
+  <path d="M1120 830 L1120 870 Q1120 900 950 900 L780 900" class="arrow" marker-end="url(#ah)"/>
+
+  <!-- ═════ Shared storage + response band ═════ -->
+  <g filter="url(#soft)">
+    <rect x="40" y="880" width="1420" height="180" rx="10" class="lane-shared" stroke="#d97706" stroke-width="1.5"/>
+  </g>
+  <text x="60" y="908" class="box-title">Shared storage + persistence (both paths converge)</text>
+
+  <!-- StorageBackend box -->
+  <rect x="60" y="924" width="420" height="116" rx="8" fill="#ffffff" stroke="#d97706" stroke-width="1"/>
+  <text x="80" y="948" class="box-title">StorageBackend.upload</text>
+  <text x="80" y="968" class="item">• compute BLAKE3 ciphertext hash</text>
+  <text x="80" y="988" class="item">• stream ciphertext into Arion (awaited)</text>
+  <text x="80" y="1008" class="item">• round-robin across configured Arion endpoints</text>
+  <text x="80" y="1028" class="code">returns arion_hash</text>
+
+  <!-- Database box -->
+  <rect x="500" y="924" width="420" height="116" rx="8" fill="#ffffff" stroke="#6b7280" stroke-width="1"/>
+  <text x="520" y="948" class="box-title">PostgreSQL · upsert_file_checked</text>
+  <text x="520" y="968" class="item">• atomic CAS on base_revision_id</text>
+  <text x="520" y="988" class="item">• returns 409 Conflict if stale</text>
+  <text x="520" y="1008" class="item">• update_user_summary (bytes / count delta)</text>
+  <text x="520" y="1028" class="code">file_records row + user_storage_summary</text>
+
+  <!-- Billing + response -->
+  <rect x="940" y="924" width="500" height="116" rx="8" fill="#ffffff" stroke="#a21caf" stroke-width="1"/>
+  <text x="960" y="948" class="box-title">Async side-effects + response</text>
+  <text x="960" y="968" class="item">• spawn billing push (JoinSet, non-blocking)</text>
+  <text x="960" y="988" class="item">• emit metrics (<tspan class="code">record_upload_result</tspan>)</text>
+  <text x="960" y="1008" class="item">• HCFS → <tspan class="code-b">UploadResult { revision_id }</tspan></text>
+  <text x="960" y="1028" class="item">• S3 gateway → <tspan class="code-b">S3UploadResult { file_id, revision_id }</tspan></text>
+
+  <!-- Legend -->
+  <g transform="translate(60, 1085)">
+    <rect x="0" y="-13" width="14" height="14" fill="#eff6ff" stroke="#3b82f6"/>
+    <text x="20" y="-1" class="item">HCFS native path</text>
+    <rect x="160" y="-13" width="14" height="14" fill="#ecfeff" stroke="#0891b2"/>
+    <text x="180" y="-1" class="item">S3 gateway path</text>
+    <rect x="310" y="-13" width="14" height="14" fill="#fff7ed" stroke="#d97706"/>
+    <text x="330" y="-1" class="item">Shared on server</text>
+    <line x1="450" y1="-6" x2="490" y2="-6" class="arrow-async"/>
+    <text x="498" y="-1" class="item">async / fire-and-forget</text>
+  </g>
+</svg>

--- a/static/img/hcfs/diagrams/03-sync-engine.svg
+++ b/static/img/hcfs/diagrams/03-sync-engine.svg
@@ -1,0 +1,321 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1500 1280" width="1500" height="1280" role="img" aria-label="HCFS sync engine three-tree flow">
+  <defs>
+    <style><![CDATA[
+      .bg { fill: #fafafa; }
+      .title { font: 700 28px -apple-system, "Segoe UI", sans-serif; fill: #111827; }
+      .subtitle { font: 400 14px -apple-system, sans-serif; fill: #4b5563; }
+      .section-tag { font: 700 11px -apple-system, sans-serif; letter-spacing: 0.12em; fill: #6b7280; }
+      .box-title { font: 700 14px -apple-system, sans-serif; fill: #111827; }
+      .box-sub { font: 400 11px -apple-system, sans-serif; fill: #6b7280; }
+      .item { font: 400 12px -apple-system, sans-serif; fill: #1f2937; }
+      .item-sm { font: 400 11px -apple-system, sans-serif; fill: #374151; }
+      .code { font: 400 11px ui-monospace, SFMono-Regular, Menlo, monospace; fill: #374151; }
+      .code-b { font: 600 11px ui-monospace, SFMono-Regular, Menlo, monospace; fill: #111827; }
+      .edge { font: 600 11px -apple-system, sans-serif; fill: #1f2937; }
+      .edge-sub { font: 400 10px -apple-system, sans-serif; fill: #6b7280; }
+      .matrix-h { font: 700 11px -apple-system, sans-serif; fill: #111827; }
+      .matrix-c { font: 400 11px ui-monospace, Menlo, monospace; fill: #1f2937; text-anchor: middle; }
+      .matrix-act { font: 600 11px -apple-system, sans-serif; fill: #1f2937; }
+      .arrow { stroke: #374151; stroke-width: 1.8; fill: none; }
+      .arrow-thin { stroke: #6b7280; stroke-width: 1.2; fill: none; }
+      .arrow-bold { stroke: #111827; stroke-width: 2.4; fill: none; }
+      .arrow-async { stroke: #7c3aed; stroke-width: 1.6; fill: none; stroke-dasharray: 5 4; }
+      .divider { stroke: #e5e7eb; stroke-width: 1; stroke-dasharray: 4 4; }
+    ]]></style>
+    <marker id="ah" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#374151"/>
+    </marker>
+    <marker id="ah-bold" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#111827"/>
+    </marker>
+    <marker id="ah-thin" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#6b7280"/>
+    </marker>
+    <filter id="soft" x="-5%" y="-5%" width="110%" height="110%">
+      <feDropShadow dx="0" dy="1" stdDeviation="1.5" flood-color="#0f172a" flood-opacity="0.08"/>
+    </filter>
+  </defs>
+
+  <rect class="bg" width="1500" height="1280"/>
+
+  <!-- Title -->
+  <text x="60" y="52" class="title">HCFS sync engine · three-tree comparison</text>
+  <text x="60" y="78" class="subtitle">Client-side. <tspan class="code-b">SyncRunner</tspan> drives <tspan class="code-b">Drive::sync_with_resolver</tspan>, which scans, fetches, classifies with <tspan class="code-b">SyncPlan::build</tspan>, and executes upload/download/rename/delete — persisting the new synced tree.</text>
+
+  <!-- ═════════════ Inputs row ═════════════ -->
+  <text x="60" y="124" class="section-tag">INPUTS · three trees + auxiliary signals</text>
+
+  <!-- Local tree -->
+  <g filter="url(#soft)">
+    <rect x="60" y="140" width="320" height="170" rx="10" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  </g>
+  <text x="82" y="166" class="box-title">Local tree</text>
+  <text x="82" y="182" class="box-sub">scan_local_files (drive/scan.rs)</text>
+  <text x="82" y="206" class="item">• walk sync root, apply exclude rules</text>
+  <text x="82" y="224" class="item">• mtime cache skips unchanged files</text>
+  <text x="82" y="242" class="item">• computes <tspan class="code">path_hash</tspan> + <tspan class="code">salted_hash</tspan></text>
+  <text x="82" y="260" class="item">• result: <tspan class="code-b">FileTree</tspan> keyed by FileId</text>
+  <text x="82" y="286" class="code">source: disk</text>
+
+  <!-- Remote tree -->
+  <g filter="url(#soft)">
+    <rect x="400" y="140" width="320" height="170" rx="10" fill="#fff7ed" stroke="#d97706" stroke-width="1.5"/>
+  </g>
+  <text x="422" y="166" class="box-title">Remote tree</text>
+  <text x="422" y="182" class="box-sub">HcfsClient::get_state (paged)</text>
+  <text x="422" y="206" class="item">• fetches by ss58 + folder_hash</text>
+  <text x="422" y="224" class="item">• reconcile_remote_timestamps</text>
+  <text x="422" y="242" class="item">• detects stale local state</text>
+  <text x="422" y="260" class="item">• result: <tspan class="code-b">FileTree</tspan> from server</text>
+  <text x="422" y="286" class="code">source: server</text>
+
+  <!-- Synced tree -->
+  <g filter="url(#soft)">
+    <rect x="740" y="140" width="320" height="170" rx="10" fill="#f3f4f6" stroke="#6b7280" stroke-width="1.5"/>
+  </g>
+  <text x="762" y="166" class="box-title">Synced tree (merge base)</text>
+  <text x="762" y="182" class="box-sub">.hippius/sync_state.json</text>
+  <text x="762" y="206" class="item">• last known reconciled state</text>
+  <text x="762" y="224" class="item">• atomically written with .bak</text>
+  <text x="762" y="242" class="item">• advances only on successful sync</text>
+  <text x="762" y="260" class="item">• rekey_file_id on renames</text>
+  <text x="762" y="286" class="code">source: local cache</text>
+
+  <!-- Auxiliary signals -->
+  <g filter="url(#soft)">
+    <rect x="1080" y="140" width="360" height="170" rx="10" fill="#f5f3ff" stroke="#7c3aed" stroke-width="1.5"/>
+  </g>
+  <text x="1102" y="166" class="box-title">Auxiliary signals</text>
+  <text x="1102" y="182" class="box-sub">engine/runner.rs · sync/rename.rs</text>
+  <text x="1102" y="206" class="item">• <tspan class="code-b">PathRenameHint</tspan> from <tspan class="code">notify</tspan> watcher</text>
+  <text x="1102" y="224" class="item">• <tspan class="code-b">excluded_ids</tspan> from exclude rules</text>
+  <text x="1102" y="242" class="item">• cancel token (graceful shutdown)</text>
+  <text x="1102" y="260" class="item">• SyncMode (normal / force-upload / …)</text>
+  <text x="1102" y="286" class="code">feeds Tier 1 rename detection</text>
+
+  <!-- Down arrows -->
+  <path d="M220 310 L220 360" class="arrow" marker-end="url(#ah)"/>
+  <path d="M560 310 L560 360" class="arrow" marker-end="url(#ah)"/>
+  <path d="M900 310 L900 360" class="arrow" marker-end="url(#ah)"/>
+  <path d="M1260 310 L1260 360" class="arrow" marker-end="url(#ah)"/>
+
+  <!-- ═════════════ SyncPlan::build ═════════════ -->
+  <text x="60" y="346" class="section-tag">PLAN · SyncPlan::build (sync/plan.rs)</text>
+  <g filter="url(#soft)">
+    <rect x="60" y="360" width="1380" height="370" rx="12" fill="#fffbeb" stroke="#ca8a04" stroke-width="1.5"/>
+  </g>
+  <text x="80" y="388" class="box-title">classify_file — for every FileId present in any tree</text>
+
+  <!-- Classification matrix -->
+  <g transform="translate(80,408)">
+    <!-- Header row -->
+    <rect x="0" y="0" width="720" height="28" fill="#fef3c7" stroke="#ca8a04"/>
+    <text x="40" y="18" class="matrix-h" text-anchor="middle">Local</text>
+    <text x="120" y="18" class="matrix-h" text-anchor="middle">Remote</text>
+    <text x="200" y="18" class="matrix-h" text-anchor="middle">Synced</text>
+    <text x="420" y="18" class="matrix-h">→ Action</text>
+
+    <!-- Rows -->
+    <g font-family="ui-monospace, Menlo, monospace" font-size="11">
+      <!-- row helper style done inline -->
+      <rect x="0" y="28" width="720" height="22" fill="#ffffff"/>
+      <text x="40" y="43" class="matrix-c">A</text>
+      <text x="120" y="43" class="matrix-c">A</text>
+      <text x="200" y="43" class="matrix-c">A</text>
+      <text x="280" y="43" class="matrix-act">Unchanged</text>
+
+      <rect x="0" y="50" width="720" height="22" fill="#f9fafb"/>
+      <text x="40" y="65" class="matrix-c">A</text>
+      <text x="120" y="65" class="matrix-c">—</text>
+      <text x="200" y="65" class="matrix-c">—</text>
+      <text x="280" y="65" class="matrix-act" fill="#2563eb">LocalCreate → upload</text>
+
+      <rect x="0" y="72" width="720" height="22" fill="#ffffff"/>
+      <text x="40" y="87" class="matrix-c">—</text>
+      <text x="120" y="87" class="matrix-c">A</text>
+      <text x="200" y="87" class="matrix-c">—</text>
+      <text x="280" y="87" class="matrix-act" fill="#2563eb">RemoteCreate → download</text>
+
+      <rect x="0" y="94" width="720" height="22" fill="#f9fafb"/>
+      <text x="40" y="109" class="matrix-c">A′</text>
+      <text x="120" y="109" class="matrix-c">A</text>
+      <text x="200" y="109" class="matrix-c">A</text>
+      <text x="280" y="109" class="matrix-act" fill="#2563eb">LocalModify → upload</text>
+
+      <rect x="0" y="116" width="720" height="22" fill="#ffffff"/>
+      <text x="40" y="131" class="matrix-c">A</text>
+      <text x="120" y="131" class="matrix-c">A′</text>
+      <text x="200" y="131" class="matrix-c">A</text>
+      <text x="280" y="131" class="matrix-act" fill="#2563eb">RemoteModify → download</text>
+
+      <rect x="0" y="138" width="720" height="22" fill="#f9fafb"/>
+      <text x="40" y="153" class="matrix-c">—</text>
+      <text x="120" y="153" class="matrix-c">A</text>
+      <text x="200" y="153" class="matrix-c">A</text>
+      <text x="280" y="153" class="matrix-act" fill="#ca8a04">LocalDelete → remote delete</text>
+
+      <rect x="0" y="160" width="720" height="22" fill="#ffffff"/>
+      <text x="40" y="175" class="matrix-c">A</text>
+      <text x="120" y="175" class="matrix-c">—</text>
+      <text x="200" y="175" class="matrix-c">A</text>
+      <text x="280" y="175" class="matrix-act" fill="#ca8a04">RemoteDelete → local delete</text>
+
+      <rect x="0" y="182" width="720" height="22" fill="#f9fafb"/>
+      <text x="40" y="197" class="matrix-c">A</text>
+      <text x="120" y="197" class="matrix-c">A</text>
+      <text x="200" y="197" class="matrix-c">—</text>
+      <text x="280" y="197" class="matrix-act">BothModifiedSame → Unchanged</text>
+
+      <rect x="0" y="204" width="720" height="22" fill="#ffffff"/>
+      <text x="40" y="219" class="matrix-c">—</text>
+      <text x="120" y="219" class="matrix-c">—</text>
+      <text x="200" y="219" class="matrix-c">A</text>
+      <text x="280" y="219" class="matrix-act">BothDeleted → Unchanged</text>
+
+      <rect x="0" y="226" width="720" height="22" fill="#fee2e2"/>
+      <text x="40" y="241" class="matrix-c">A′</text>
+      <text x="120" y="241" class="matrix-c">A″</text>
+      <text x="200" y="241" class="matrix-c">A</text>
+      <text x="280" y="241" class="matrix-act" fill="#dc2626">Conflict · ModifyModify</text>
+
+      <rect x="0" y="248" width="720" height="22" fill="#fee2e2"/>
+      <text x="40" y="263" class="matrix-c">A′</text>
+      <text x="120" y="263" class="matrix-c">—</text>
+      <text x="200" y="263" class="matrix-c">A</text>
+      <text x="280" y="263" class="matrix-act" fill="#dc2626">Conflict · ModifyDelete</text>
+
+      <rect x="0" y="270" width="720" height="22" fill="#fee2e2"/>
+      <text x="40" y="285" class="matrix-c">—</text>
+      <text x="120" y="285" class="matrix-c">A′</text>
+      <text x="200" y="285" class="matrix-c">A</text>
+      <text x="280" y="285" class="matrix-act" fill="#dc2626">Conflict · DeleteModify</text>
+
+      <rect x="0" y="292" width="720" height="22" fill="#fee2e2"/>
+      <text x="40" y="307" class="matrix-c">A</text>
+      <text x="120" y="307" class="matrix-c">B</text>
+      <text x="200" y="307" class="matrix-c">—</text>
+      <text x="280" y="307" class="matrix-act" fill="#dc2626">Conflict · CreateCreate</text>
+    </g>
+    <text x="0" y="334" class="item-sm">Legend: A / A′ / A″ = distinct salted_hash · — = absent from tree · excluded_ids short-circuits to LocalSkip</text>
+  </g>
+
+  <!-- Rename detection panel -->
+  <g transform="translate(830,408)">
+    <rect x="0" y="0" width="590" height="310" rx="8" fill="#ffffff" stroke="#ca8a04" stroke-width="1"/>
+    <text x="20" y="26" class="box-title">extract_renames — two-tier detection</text>
+    <text x="20" y="44" class="box-sub">runs after classification; replaces upload+remote_delete pairs</text>
+
+    <rect x="20" y="60" width="550" height="104" rx="6" fill="#f5f3ff" stroke="#7c3aed"/>
+    <text x="40" y="84" class="box-title">Tier 1 · watcher hints</text>
+    <text x="40" y="104" class="item">• <tspan class="code">PathRenameHint { old, new }</tspan> from notify</text>
+    <text x="40" y="122" class="item">• match <tspan class="code">path_hash(old)</tspan> in remote_deletes and <tspan class="code">path_hash(new)</tspan> in uploads</text>
+    <text x="40" y="140" class="item">• accept only if salted_hash matches and size &gt; 0</text>
+    <text x="40" y="158" class="item-sm">Reject hint when content changed → fall back to upload + delete</text>
+
+    <rect x="20" y="176" width="550" height="88" rx="6" fill="#fef3c7" stroke="#ca8a04"/>
+    <text x="40" y="200" class="box-title">Tier 2 · content-hash pairing</text>
+    <text x="40" y="220" class="item">• bucket remaining uploads + remote_deletes by salted_hash</text>
+    <text x="40" y="238" class="item">• pair equal-content non-empty entries → RenameOp</text>
+    <text x="40" y="256" class="item">• empty files deliberately excluded (shared hash → false matches)</text>
+
+    <text x="20" y="288" class="code">output: plan.renames[] executes as batch POST /rename_files</text>
+  </g>
+
+  <!-- Arrow to plan buckets -->
+  <path d="M750 730 L750 770" class="arrow-bold" marker-end="url(#ah-bold)"/>
+
+  <!-- ═════════════ Plan buckets ═════════════ -->
+  <text x="60" y="766" class="section-tag">SYNC PLAN · output buckets</text>
+
+  <g filter="url(#soft)">
+    <rect x="60" y="780" width="1380" height="90" rx="10" fill="#ffffff" stroke="#374151" stroke-width="1.5"/>
+  </g>
+  <g font-size="12" font-family="-apple-system, sans-serif">
+    <rect x="80"  y="800" width="160" height="54" rx="6" fill="#dbeafe" stroke="#2563eb"/>
+    <text x="160" y="822" class="matrix-act" text-anchor="middle">uploads</text>
+    <text x="160" y="840" class="code" text-anchor="middle">Vec&lt;FileId&gt;</text>
+
+    <rect x="250" y="800" width="160" height="54" rx="6" fill="#dbeafe" stroke="#2563eb"/>
+    <text x="330" y="822" class="matrix-act" text-anchor="middle">downloads</text>
+    <text x="330" y="840" class="code" text-anchor="middle">Vec&lt;FileId&gt;</text>
+
+    <rect x="420" y="800" width="160" height="54" rx="6" fill="#fed7aa" stroke="#ca8a04"/>
+    <text x="500" y="822" class="matrix-act" text-anchor="middle">local_deletes</text>
+    <text x="500" y="840" class="code" text-anchor="middle">Vec&lt;FileId&gt;</text>
+
+    <rect x="590" y="800" width="160" height="54" rx="6" fill="#fed7aa" stroke="#ca8a04"/>
+    <text x="670" y="822" class="matrix-act" text-anchor="middle">remote_deletes</text>
+    <text x="670" y="840" class="code" text-anchor="middle">Vec&lt;FileId&gt;</text>
+
+    <rect x="760" y="800" width="160" height="54" rx="6" fill="#ede9fe" stroke="#7c3aed"/>
+    <text x="840" y="822" class="matrix-act" text-anchor="middle">renames</text>
+    <text x="840" y="840" class="code" text-anchor="middle">Vec&lt;RenameOp&gt;</text>
+
+    <rect x="930" y="800" width="160" height="54" rx="6" fill="#fee2e2" stroke="#dc2626"/>
+    <text x="1010" y="822" class="matrix-act" text-anchor="middle">conflicts</text>
+    <text x="1010" y="840" class="code" text-anchor="middle">Vec&lt;SyncConflictInfo&gt;</text>
+
+    <rect x="1100" y="800" width="160" height="54" rx="6" fill="#f3f4f6" stroke="#6b7280"/>
+    <text x="1180" y="822" class="matrix-act" text-anchor="middle">unchanged</text>
+    <text x="1180" y="840" class="code" text-anchor="middle">Vec&lt;FileId&gt;</text>
+
+    <rect x="1270" y="800" width="150" height="54" rx="6" fill="#f3f4f6" stroke="#6b7280"/>
+    <text x="1345" y="822" class="matrix-act" text-anchor="middle">excluded</text>
+    <text x="1345" y="840" class="code" text-anchor="middle">Vec&lt;FileId&gt;</text>
+  </g>
+
+  <!-- Arrow to execute -->
+  <path d="M750 870 L750 910" class="arrow-bold" marker-end="url(#ah-bold)"/>
+
+  <!-- ═════════════ Execute sync plan ═════════════ -->
+  <text x="60" y="906" class="section-tag">EXECUTE · Drive::execute_sync_plan (drive/sync_flow.rs)</text>
+
+  <g filter="url(#soft)">
+    <rect x="60" y="920" width="1380" height="210" rx="12" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  </g>
+
+  <!-- Conflicts pre-step -->
+  <rect x="80" y="940" width="340" height="170" rx="8" fill="#fee2e2" stroke="#dc2626"/>
+  <text x="100" y="964" class="box-title">1. Resolve conflicts (if any)</text>
+  <text x="100" y="984" class="item">• pass each <tspan class="code-b">SyncConflictInfo</tspan> to user</text>
+  <text x="100" y="1002" class="item">  resolver callback</text>
+  <text x="100" y="1020" class="item">• resolutions:</text>
+  <text x="120" y="1038" class="code">KeepLocal · AcceptRemote</text>
+  <text x="120" y="1054" class="code">KeepBoth · Skip</text>
+  <text x="100" y="1078" class="item">• may rewrite plan into uploads /</text>
+  <text x="100" y="1094" class="item">  downloads / conflict-copies</text>
+
+  <!-- Concurrent ops -->
+  <rect x="440" y="940" width="460" height="170" rx="8" fill="#dbeafe" stroke="#2563eb"/>
+  <text x="460" y="964" class="box-title">2. Concurrent I/O (bounded)</text>
+  <text x="460" y="984" class="item">Uploads</text>
+  <text x="480" y="1002" class="code">encrypt_stream → HcfsClient::upload</text>
+  <text x="480" y="1018" class="code">→ upsert_file_checked (revision CAS)</text>
+  <text x="460" y="1040" class="item">Downloads</text>
+  <text x="480" y="1058" class="code">HcfsClient::download → decrypt_stream</text>
+  <text x="480" y="1074" class="code">→ atomic temp-file rename into place</text>
+  <text x="460" y="1096" class="item-sm">joins on CancellationToken for graceful shutdown</text>
+
+  <!-- Serial ops -->
+  <rect x="920" y="940" width="500" height="170" rx="8" fill="#fed7aa" stroke="#ca8a04"/>
+  <text x="940" y="964" class="box-title">3. Serial ops + state merge</text>
+  <text x="940" y="984" class="item">Renames</text>
+  <text x="960" y="1002" class="code">POST /rename_files (batch)</text>
+  <text x="940" y="1022" class="item">Local deletes</text>
+  <text x="960" y="1040" class="code">fs::remove_file + synced_tree update</text>
+  <text x="940" y="1060" class="item">Remote deletes</text>
+  <text x="960" y="1078" class="code">HcfsClient::delete → drop from trees</text>
+  <text x="940" y="1100" class="item-sm">all successes fold into new synced tree</text>
+
+  <!-- Down arrow to outcome -->
+  <path d="M750 1130 L750 1170" class="arrow-bold" marker-end="url(#ah-bold)"/>
+
+  <!-- ═════════════ Outcome ═════════════ -->
+  <text x="60" y="1166" class="section-tag">OUTCOME</text>
+  <g filter="url(#soft)">
+    <rect x="60" y="1180" width="1380" height="80" rx="10" fill="#ecfdf5" stroke="#059669" stroke-width="1.5"/>
+  </g>
+  <text x="80" y="1206" class="box-title">SyncOutcome → SyncRunner</text>
+  <text x="80" y="1226" class="item">• persist new <tspan class="code-b">synced</tspan> tree atomically (.json + .bak)   •   <tspan class="code">rekey_file_id</tspan> on rename   •   emit throttled progress snapshot (<tspan class="code">emit_snapshot</tspan>)</text>
+  <text x="80" y="1244" class="item">• run post-sync hooks (fire-and-forget)   •   update activity log (<tspan class="code">push_dedup</tspan>)   •   reset health / failure counters or record a retry</text>
+</svg>


### PR DESCRIPTION
## Summary

- Port the HCFS public docs (integration guide, architecture diagrams, REST API reference) into the Docusaurus site under a new top-level **HCFS** sidebar category.
- Adds 16 markdown pages (guide, diagrams, API overview + 13 endpoint pages) and 3 architecture SVGs served from `/img/hcfs/diagrams/`.
- Updates `sidebars.ts` with an `HCFS` category that nests `integration-guide`, `architecture-diagrams`, and a `REST API` subcategory.

## Adaptations for Docusaurus / MDX v3

- Added frontmatter (`id`, `title`, `sidebar_label`, `slug`) to every ported page.
- Renamed `api/README.md` → `api/overview.md` and updated the single inbound link from `integration-guide.md`.
- Wrapped URL path templates in H1/H2 lines with backticks so MDX does not parse `{ss58}` / `{file_id}` / `{folder_hash}` as JavaScript identifiers.
- Rewrote the SVG references in `architecture-diagrams.md` from `diagrams/*.svg` to absolute `/img/hcfs/diagrams/*.svg` paths.
- Added explicit `{#anchor-id}` attributes to endpoint H2s in `upload-session.md`, `s3-gateway.md`, and `folders.md` so the anchor links from `overview.md` resolve.

## Test plan

- [x] `pnpm install && pnpm docusaurus build --locale en` — build succeeds with no new warnings.
- [x] All 16 HCFS pages generate under `build/hcfs/` and the 3 SVGs land in `build/img/hcfs/diagrams/`.
- [x] Anchor links between `overview.md` and endpoint pages (`upload-session`, `s3-gateway`, `folders`) resolve — only pre-existing unrelated `use/desktop/settings` anchor warnings remain.
- [ ] Manual sidebar + navigation spot-check in `pnpm dev`.