### PR TITLE
style(navbar): color Hippius wordmark in brand blue

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -512,3 +512,10 @@ article .theme-doc-breadcrumbs {
 .navbar__logo img {
   filter: drop-shadow(0 1px 2px rgb(0 0 0 / 0.3));
 }
+
+/* Hippius wordmark in brand blue (matches the console). --primary-50 stays
+   #3167DD in both light and dark mode, and the navbar background is light/dark
+   (never blue), so the blue title reads in both themes. */
+.navbar__brand .navbar__title {
+  color: rgb(var(--primary-50));
+}


### PR DESCRIPTION
## Summary
Colors the Hippius navbar wordmark in the brand blue (`--primary-50` / #3167DD) so the title matches the console branding. Mirrors the same change shipped in docs-internal to keep the public docs aligned.

## Changes
- `src/css/custom.css`: set `.navbar__brand .navbar__title` color to `rgb(var(--primary-50))`. The variable stays #3167DD in both light and dark mode, and the navbar background is never blue, so the title reads clearly in both themes.