### PR TITLE
Add llms.txt link to footer

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -272,6 +272,8 @@ const config: Config = {
         <a class="footer__legal-link" href="https://hippius.com/privacy-policy" target="_blank" rel="noopener noreferrer">Privacy Policy</a>
         <span class="footer__legal-dot" aria-hidden="true">&bull;</span>
         <a class="footer__legal-link" href="https://hippius.com/acceptable-use-policy" target="_blank" rel="noopener noreferrer">Acceptable Use Policy</a>
+        <span class="footer__legal-dot" aria-hidden="true">&bull;</span>
+        <a class="footer__legal-link" href="https://docs.hippius.com/llms.txt" target="_blank" rel="noopener noreferrer">llms.txt</a>
       </span>`,
     },
     prism: {


### PR DESCRIPTION
Adds a link to https://docs.hippius.com/llms.txt in the site footer.

## Changes
- Add `llms.txt` link to the footer legal row, alongside the existing Terms / Privacy / Acceptable Use Policy links

🤖 Generated with [Claude Code](https://claude.com/claude-code)