### PR TITLE
feat(footer): move llms.txt link into the Use column

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -227,6 +227,10 @@ const config: Config = {
               label: "Hippius Community",
               href: "https://community.hippius.com/",
             },
+            {
+              label: "llms.txt",
+              href: "https://docs.hippius.com/llms.txt",
+            },
           ],
         },
         {
@@ -281,8 +285,6 @@ const config: Config = {
         <a class="footer__legal-link" href="https://hippius.com/privacy-policy" target="_blank" rel="noopener noreferrer">Privacy Policy</a>
         <span class="footer__legal-dot" aria-hidden="true">&bull;</span>
         <a class="footer__legal-link" href="https://hippius.com/acceptable-use-policy" target="_blank" rel="noopener noreferrer">Acceptable Use Policy</a>
-        <span class="footer__legal-dot" aria-hidden="true">&bull;</span>
-        <a class="footer__legal-link" href="https://docs.hippius.com/llms.txt" target="_blank" rel="noopener noreferrer">llms.txt</a>
       </span>`,
     },
     prism: {


### PR DESCRIPTION
## What

Moves the **llms.txt** footer link out of the bottom legal bar and into the **Use** column, next to Quickstart / Hipstats / Hippius Community — where a resource link reads more naturally than beside Terms / Privacy / Acceptable Use.

Follows up on #43 (which introduced the link in the legal bar). The `headTags` `<link rel="alternate" type="text/plain" href="/llms.txt">` is left untouched.