### PR TITLE
docs(registry): describe Hub by capability, not by implementation

### DIFF
--- a/docs/registry/cli.md
+++ b/docs/registry/cli.md
@@ -31,7 +31,7 @@ Published wheels include the pre-built Rust core, so no toolchain is needed. Bui
 | For… | Use | Cached at |
 | --- | --- | --- |
 | `registry` and `models` commands | **API token** from [console.hippius.com/dashboard/settings](https://console.hippius.com/dashboard/settings) | `~/.cache/hippius/hub/api_token` |
-| `upload` / `download` (raw OCI registry IO) | Docker registry credentials | `~/.cache/hippius/hub/token` |
+| `upload` / `download` (model and artifact transfer) | Registry credentials | `~/.cache/hippius/hub/token` |
 
 In practice the API token is all you save by hand — `hippius-hub registry provision <namespace>` mints the docker credentials and writes them into the second cache for you. Pass `--docker-login` to also run `docker login` so `docker push` / `docker pull` work.
 
@@ -49,7 +49,7 @@ hippius-hub login --username <you> --password <secret>   # docker creds, manual 
 | `registry plans` | List pricing tiers and quotas |
 | `registry check <name>` | Is a namespace available? |
 | `registry provision <ns> [--docker-login]` | Create your namespace; new projects are public by default |
-| `registry me` | Plan, quota, status, and robot login of your active project |
+| `registry me` | Plan, quota, status, and registry login of your active project |
 | `registry repos [--page N --page-size M]` | List your repositories |
 | `registry artifacts <repo>` | List artifacts in one repo |
 | `registry usage` | Storage used + 7-day history |

--- a/docs/registry/pull.md
+++ b/docs/registry/pull.md
@@ -65,7 +65,7 @@ Public images pull without `docker login`. The same reference works anywhere an 
 oras pull registry.hippius.com/my-models/my-artifact:v1
 ```
 
-[`oras`](https://oras.land) pulls arbitrary OCI artifacts — model weights, datasets, anything you previously pushed with `oras push`. The Model Registry stores model files this way under the hood.
+[`oras`](https://oras.land) pulls arbitrary content-addressed artifacts — datasets, configs, anything you previously pushed with `oras push`.
 
 </TabItem>
 </Tabs>
@@ -110,7 +110,7 @@ A Docker image is one manifest — `docker pull <image>:<tag>` already pulls eve
 
 ## Tag vs digest
 
-Tags (`:v1`, `:main`) are **mutable** — re-pushing to the same revision moves the tag onto a new manifest. Digests (`@sha256:…`) are **immutable** — the same bytes forever.
+Tags (`:v1`, `:main`) are **mutable** — re-pushing to the same revision moves the tag onto the new content. Digests (`@sha256:…`) are **immutable** — the same bytes forever.
 
 - Pin to a **digest** for CI/CD, Kubernetes manifests, and anywhere reproducibility matters.
 - Use a **tag** for interactive development and the "give me the latest" case.

--- a/docs/registry/push.md
+++ b/docs/registry/push.md
@@ -32,8 +32,8 @@ hippius-hub registry provision my-models --docker-login
 
 `provision --docker-login` does three things in one shot: creates your namespace, mints docker credentials, and runs `docker login registry.hippius.com` for you. The hippius-hub CLI's own `upload` / `download` commands also start working immediately because the credentials are cached at `~/.cache/hippius/hub/token`.
 
-:::tip Save the robot secret
-The robot secret prints **once** at the bottom of `registry provision`. If you lose it, rotate with `hippius-hub registry rotate-token` — it issues a new secret and updates the local cache.
+:::tip Save the registry secret
+The registry secret prints **once** at the bottom of `registry provision`. If you lose it, rotate with `hippius-hub registry rotate-token` — it issues a new secret and updates the local cache.
 :::
 
 ---
@@ -56,7 +56,7 @@ upload_folder(
 )
 ```
 
-Drop-in for [`upload_folder`](https://huggingface.co/docs/huggingface_hub/guides/upload#upload-a-folder). Re-running it merges into the existing manifest at that revision — individual files get added or replaced without wiping the rest.
+Drop-in for [`upload_folder`](https://huggingface.co/docs/huggingface_hub/guides/upload#upload-a-folder). Re-running it merges into the existing revision — individual files get added or replaced without wiping the rest.
 
 For a single file, use `upload_file(path_or_fileobj, path_in_repo, repo_id, revision)`.
 
@@ -74,7 +74,7 @@ hippius-hub upload my-models/qwen-7b ./README.md --revision v1
 hippius-hub upload my-models/qwen-7b ./qwen-7b
 ```
 
-Folder uploads **merge** into the existing manifest — re-running adds or replaces individual files without wiping the rest. The indexer picks up format / architecture / parameter count / quantization within a few seconds of the push completing.
+Folder uploads **merge** into the existing revision — re-running adds or replaces individual files without wiping the rest. The indexer picks up format / architecture / parameter count / quantization within a few seconds of the push completing.
 
 </TabItem>
 <TabItem value="docker" label="Docker">
@@ -94,7 +94,7 @@ oras push registry.hippius.com/my-models/my-artifact:v1 \
   ./weights.safetensors ./config.json
 ```
 
-[`oras`](https://oras.land) pushes arbitrary files as OCI artifacts. This is how the Model Registry stores model weights under the hood — but you can use it directly for datasets, configs, or anything else you want to address by name and digest.
+[`oras`](https://oras.land) pushes arbitrary files as content-addressed artifacts — useful for datasets, configs, or anything else you want to address by name and digest.
 
 </TabItem>
 </Tabs>
@@ -152,7 +152,7 @@ If `docker push` loops with `500 Cannot find server.`, check `docker info | grep
 ---
 
 :::note Hugging Face features not supported
-Inference Endpoints, Spaces, Webhooks, Collections, and Discussions raise `NotImplementedError` — they have no OCI equivalent. Everything required for `from_pretrained` works.
+Inference Endpoints, Spaces, Webhooks, Collections, and Discussions raise `NotImplementedError` — they have no Hippius equivalent. Everything required for `from_pretrained` works.
 :::
 
 ---

--- a/docs/registry/quickstart.md
+++ b/docs/registry/quickstart.md
@@ -11,16 +11,16 @@ import Screenshot from '@site/src/components/Screenshot';
 
 # Hippius Hub Registry
 
-**The AI model registry built for distributed compute.** Hippius Hub is a public registry for AI models and OCI artifacts — pull anything anonymously, push with an account.
+**The AI model registry built for distributed compute.** Hippius Hub is a public registry for AI models and container artifacts — pull anything anonymously, push with an account.
 
 It has two faces:
 
 | Face | What it is | Who uses it |
 | --- | --- | --- |
-| **Model Registry** | A drop-in replacement for [Hugging Face Hub](https://huggingface.co). Same Python API ([`hf_hub_download`](https://huggingface.co/docs/huggingface_hub/guides/download#download-a-single-file), [`snapshot_download`](https://huggingface.co/docs/huggingface_hub/guides/download#download-an-entire-repository), [`from_pretrained`](https://huggingface.co/docs/transformers/main_classes/model#transformers.PreTrainedModel.from_pretrained)), backed by an OCI registry instead of huggingface.co. | ML engineers loading models with `transformers`, `diffusers`, or any library that uses [`huggingface_hub`](https://huggingface.co/docs/huggingface_hub/index) under the hood. |
-| **Container Registry** | A standard OCI registry. Push and pull Docker images, ORAS artifacts, and raw OCI blobs against `registry.hippius.com`. | Anyone running `docker push` / `docker pull`, plus power users with `oras` for non-image artifacts. |
+| **Model Registry** | A drop-in replacement for [Hugging Face Hub](https://huggingface.co). Same Python API ([`hf_hub_download`](https://huggingface.co/docs/huggingface_hub/guides/download#download-a-single-file), [`snapshot_download`](https://huggingface.co/docs/huggingface_hub/guides/download#download-an-entire-repository), [`from_pretrained`](https://huggingface.co/docs/transformers/main_classes/model#transformers.PreTrainedModel.from_pretrained)), served by Hippius instead of huggingface.co. | ML engineers loading models with `transformers`, `diffusers`, or any library that uses [`huggingface_hub`](https://huggingface.co/docs/huggingface_hub/index) under the hood. |
+| **Container Registry** | Docker-compatible. Push and pull Docker images and ORAS artifacts against `registry.hippius.com`. | Anyone running `docker push` / `docker pull`, plus power users with `oras` for non-image artifacts. |
 
-Both faces share the same authentication, the same backing storage, and the same endpoint.
+Both faces share the same authentication and the same endpoint.
 
 ---
 
@@ -28,7 +28,7 @@ Both faces share the same authentication, the same backing storage, and the same
 
 | Purpose | URL |
 | --- | --- |
-| OCI registry (Docker, ORAS, `hippius-hub`) | `registry.hippius.com` |
+| Registry endpoint (Docker, ORAS, `hippius-hub`) | `registry.hippius.com` |
 | Web UI (browse models & containers) | [`hub.hippius.com`](https://hub.hippius.com) |
 | Source / issues | [`github.com/thenervelab/hippius-hub`](https://github.com/thenervelab/hippius-hub) |
 


### PR DESCRIPTION
## Summary

The registry pages repeatedly explained the Model Registry in terms of *what it is built on* rather than *what it does*. Read together, they told a reader that the model side is a thin layer over the container side:

- "…**backed by an OCI registry** instead of huggingface.co"
- "`upload` / `download` (**raw OCI registry IO**)"
- "This is how the Model Registry stores model weights **under the hood**" (push.md)
- "The Model Registry stores model files this way **under the hood**" (pull.md)
- "Both faces share the same authentication, **the same backing storage**, and the same endpoint"

This reframes all of it around capability. No commands, endpoints, or behaviour change — 15 lines, prose only.

## What was deliberately kept

Every `docker push` / `docker pull` / `oras` example, and the Docker-compatibility promise for the Container Registry. That's a real feature people need documented; the change is that it now reads as a Hippius capability in its own right rather than as the substrate the Model Registry rides on.

Docker-specific vocabulary *inside the Docker tabs* also stays — "a Docker image is one manifest" describes Docker, not us. Same for "Kubernetes manifests".

## Changes

| File | Change |
|---|---|
| `quickstart.md` | "backed by an OCI registry" → "served by Hippius"; "A standard OCI registry" → "Docker-compatible"; dropped "the same backing storage" from the shared-infrastructure line; "OCI registry" → "Registry endpoint" in the endpoints table |
| `push.md` | Removed the ORAS "under the hood" reveal; "existing manifest" → "existing revision" (×2); "no OCI equivalent" → "no Hippius equivalent"; "robot secret" → "registry secret" |
| `pull.md` | Removed the ORAS "under the hood" reveal; "onto a new manifest" → "onto the new content" |
| `cli.md` | "raw OCI registry IO" → "model and artifact transfer"; "robot login" → "registry login" |

`robot` is backend vocabulary users never chose, so it went too.

## Verification

`grep -rinE 'harbor|opencontainers|\boci\b' docs blog src static` now returns nothing across the whole site. `Harbor` never appeared in this repo to begin with. Docusaurus build checked.

## Note

A companion PR does the same pass on `thenervelab/hippius-hub` (README, `llms.txt`, CHANGELOG, and the engineering plans).

🤖 Generated with [Claude Code](https://claude.com/claude-code)