### PR TITLE
chore: point the X links at @Hippius_cloud

### DIFF
--- a/docs/home.md
+++ b/docs/home.md
@@ -18,4 +18,4 @@ Hippius is a **transparent, distributed, anonymous cloud storage platform** buil
 
 ## Join the Community
 
-Connect with us on [Discord](https://discord.hippius.com) or follow us on [X](https://x.com/hippius_subnet) to stay updated and get support.
+Connect with us on [Discord](https://discord.hippius.com) or follow us on [X](https://x.com/Hippius_cloud) to stay updated and get support.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -268,7 +268,7 @@ const config: Config = {
             },
             {
               label: "X",
-              href: "https://x.com/hippius_subnet",
+              href: "https://x.com/Hippius_cloud",
             },
             {
               label: "GitHub",

--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -5,10 +5,10 @@ export const URLS = {
   WHY_HIPPIUS: "https://hippius.com/why-hippius",
   DASHBOARD: "https://console.hippius.com",
   GITHUB_ORG: "https://github.com/thenervelab",
-  TWITTER: "https://x.com/hippius_subnet",
+  TWITTER: "https://x.com/Hippius_cloud",
   DISCORD: "https://discord.hippius.com",
   LEARN: "/learn/intro",
   USE: "/use/quickstart",
   API: "https://api.hippius.com/",
-  X: "https://x.com/hippius_subnet",
+  X: "https://x.com/Hippius_cloud",
 };

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -447,4 +447,4 @@ Billing:
 - Pricing: https://hippius.com/pricing
 - GitHub: https://github.com/thenervelab
 - Discord: https://discord.com/channels/1298001698874327131/1442875352484548609
-- X/Twitter: https://x.com/hippius_subnet
+- X/Twitter: https://x.com/Hippius_cloud

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -226,4 +226,4 @@ https://hippius.com/pricing
 - Console: https://console.hippius.com
 - Documentation: https://docs.hippius.com
 - API: https://api.hippius.com
-- X/Twitter: https://x.com/hippius_subnet
+- X/Twitter: https://x.com/Hippius_cloud


### PR DESCRIPTION
Updates our X handle to `@Hippius_cloud`.

Six references across five files: the footer link, the shared URL constants, the home page, and both `llms.txt` files.