### PR TITLE
docs(console): state the 48 hour unbonding period and the hAlpha gas cost

### DIFF
--- a/docs/use/console/bridge.md
+++ b/docs/use/console/bridge.md
@@ -106,6 +106,10 @@ We burn your hAlpha on Hippius and release the equivalent Alpha on Bittensor. It
 This is not a choice we made. On Bittensor, subnet Alpha only ever exists as stake, recorded per hotkey, coldkey and subnet. The spendable balance on Bittensor is TAO, and there is no free Alpha balance for it to land in. If you want liquid value out of it, unstake the Alpha on Bittensor.
 :::
 
+:::warning Leave yourself some hAlpha for gas
+This direction is signed on Hippius, so the fee comes out of your hAlpha. If you bridge every last token you will have nothing left to pay it with. Keep a little back.
+:::
+
 :::note Staked hAlpha cannot be bridged
 Only your transferable balance can leave the network. Unstake first, wait out the unbonding period, and redeem before bridging. See [Staking](/use/console/staking).
 :::

--- a/docs/use/console/staking.md
+++ b/docs/use/console/staking.md
@@ -87,9 +87,7 @@ The **Unstake** button only appears once you have something staked.
 The amount moves into **Unstaking** and stops earning rewards straight away. Once the unbonding period ends we move it to **Redeemable**.
 
 :::warning Unstaking takes two days
-The unbonding period is **48 hours**. Your tokens stay locked for that whole time before you can redeem them, and they earn nothing while they wait. We cannot shorten it, so plan ahead if you need the tokens for something else.
-
-That figure comes from the chain rather than from us: unbonding runs for 8 eras, and an era is 6 hours.
+The unbonding period is **48 hours**. Your tokens stay locked for that whole time before you can redeem them, and they earn nothing while they wait. Once you have started unstaking there is no way to speed it up, so plan ahead if you need the tokens for something else.
 :::
 
 ## Redeeming

--- a/docs/use/console/staking.md
+++ b/docs/use/console/staking.md
@@ -30,7 +30,7 @@ Underneath it, a coloured bar shows how much of your hAlpha is actually working,
 | State | What it means |
 |---|---|
 | **Staked** | Bonded and earning rewards. |
-| **Unstaking** | In the unbonding period, not yet redeemable. |
+| **Unstaking** | In the 48 hour unbonding period, not yet redeemable. |
 | **Redeemable** | Finished unbonding, ready to redeem. |
 | **Unstaked** | Held but not put to work. This is what you can stake right now. |
 
@@ -86,8 +86,10 @@ The **Unstake** button only appears once you have something staked.
 
 The amount moves into **Unstaking** and stops earning rewards straight away. Once the unbonding period ends we move it to **Redeemable**.
 
-:::warning Unstaking is not instant
-Unbonded tokens stay locked for the full unbonding period before you can redeem them. We cannot shorten it, so plan ahead if you need the tokens for something else.
+:::warning Unstaking takes two days
+The unbonding period is **48 hours**. Your tokens stay locked for that whole time before you can redeem them, and they earn nothing while they wait. We cannot shorten it, so plan ahead if you need the tokens for something else.
+
+That figure comes from the chain rather than from us: unbonding runs for 8 eras, and an era is 6 hours.
 :::
 
 ## Redeeming


### PR DESCRIPTION
Two clarifications to the Staking and Bridge pages.

**The unbonding period is now stated: 48 hours.** The page previously said tokens stay locked for "the full unbonding period" without giving a number. The Unstaking row in the states table says 48 hours too.

The note is deliberately short. It gives the duration and what it means for you, and skips the era arithmetic behind it, which is not something a reader needs in order to plan around two days.

**Bridging hAlpha back to Alpha needs hAlpha for gas.** The page warned about needing TAO on the way in but said nothing about the way out. That direction is signed on Hippius, so the fee comes out of your hAlpha, and bridging every last token leaves nothing to pay it with.

No change to the fee wording. The bridge genuinely takes no cut, so "what you send is what you receive" stands.

Docusaurus build clean.